### PR TITLE
Add PR-first rule to Critical Workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ Keys from https://developer.trafiklab.se/. Rate limit: Bronze, 50 calls/min — 
 
 ## Critical Workflows
 
+**Never push directly to `main` or `develop` — always open a PR first, even for one-line fixes.** Branch protection requires changes via PR; do not bypass it. Commit to a feature/fix branch, run the pre-PR gates, open a PR.
+
 ### Feature work
 1. Branch off `main` (always; git flow).
 2. Read `CONTEXT.md` (domain glossary — use its terms) and relevant `docs/adr/`.


### PR DESCRIPTION
## Summary

Adds a standing rule to AGENTS.md → Critical Workflows: never push directly to `main` or `develop` — always branch, run the pre-PR gates, and open a PR, even for one-line fixes.

Docs-only change (AGENTS.md, which CLAUDE.md symlinks to).

## Test plan

- Docs-only: no code touched, no tests/build/security gates applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)