### PR TITLE
Fix webcam review findings: partial errors, retry, URL allowlist, notice disclosure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,8 @@ GTFS_REGIONAL_API_KEY=
 # Trafikverket Open Data — used for the webcam layer (~450 traffic cameras)
 # Register a free account at: https://data.trafikverket.se
 # Docs: https://api.trafikinfo.trafikverket.se/
+# Optional — omit to run without Trafikverket cameras (absent source, no error;
+# only the curated/Windy cameras will show in the Webcams layer)
 VITE_TRAFIKVERKET_API_KEY=
 
 # Windy Webcam API — used for the webcam layer (Sweden-filtered cameras, linkout mode)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,6 +17,14 @@ What the app can show for a Webcam, an explicit field: `image | linkout`.
 - **`image`** — the app hotlinks a static still (`<img>` fetched directly from the source, cache-busted on refresh). The only inline media this app ever renders; see the embed boundary below.
 - **`linkout`** — the app shows metadata and a link to the source page; no inline media. Stream-only cameras and catalogue-sourced cameras (webcamcollections) are `linkout`.
 
+### Source absence vs source failure
+
+A webcam **source** (Trafikverket, Windy, the curated catalogue) is **absent** when it is not configured — e.g. its API key is omitted. Absence is a legitimate configuration: the source yields zero cameras silently, with no error surfaced.
+
+A source **fails** when it is configured but unreachable, rejects the request, or returns a malformed response. Failure is always recorded and surfaced to the user — partially (other sources still render, with a warning naming the failed source) or fully (the layer shows an error and the next enable retries).
+
+Absence is a configuration; failure is an error. The two must never be conflated in UI or logs.
+
 ### Embed boundary
 
 The webcam layer never embeds third-party players or iframes (Windy player, live streams). Doing so would set third-party cookies/storage and trip the reversal trigger in [ADR 0001](docs/adr/0001-cookieless-no-consent-popup.md), forcing a full Consent surface. Hotlinked static `<img>` is treated like OSM tile loading: the network request inherently exposes the IP, nothing more.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,7 +32,7 @@ function App() {
     CAMERA_TYPE_DEFINITIONS.map(t => t.id),
   );
 
-  const { cameras, error: webcamsError, loading: webcamsLoading } = useWebcams(webcamsEnabled);
+  const { cameras, error: webcamsError, errors: webcamsErrors, loading: webcamsLoading } = useWebcams(webcamsEnabled);
 
   const cameraCounts = useMemo(() => cameraCountsByType(cameras), [cameras]);
   const filteredCameras = useMemo(
@@ -165,6 +165,7 @@ function App() {
         onWebcamsToggle={() => setWebcamsEnabled(v => !v)}
         webcamsLoading={webcamsLoading}
         webcamsError={webcamsError}
+        webcamsErrors={webcamsErrors}
         webcamCount={filteredCameras.length}
         cameraTypeDefinitions={CAMERA_TYPE_DEFINITIONS}
         enabledCameraTypes={enabledCameraTypes}

--- a/src/components/ControlPanel.css
+++ b/src/components/ControlPanel.css
@@ -98,6 +98,13 @@
   padding-left: 24px;
 }
 
+.webcam-source-warning {
+  margin-top: 6px;
+  padding-left: 24px;
+  font-size: 12px;
+  color: var(--chrome-error-text);
+}
+
 .mode-filter {
   display: flex;
   align-items: center;

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -14,6 +14,13 @@ const TRANSPORT_MODES = [
 const MODE_COLOR_MAP = Object.fromEntries(TRANSPORT_MODES.map(m => [m.id, m.color]));
 const MODE_LABEL_MAP = Object.fromEntries(TRANSPORT_MODES.map(m => [m.id, m.label]));
 
+// Display names for webcam source slugs in partial-failure warnings.
+const SOURCE_LABELS = {
+  trafikverket: 'Trafikverket',
+  windy: 'Windy',
+  webcamcollections: 'Curated catalogue',
+};
+
 export function ControlPanel({
   vehicles = [],
   loading = false,
@@ -36,6 +43,7 @@ export function ControlPanel({
   onWebcamsToggle = () => {},
   webcamsLoading = false,
   webcamsError = null,
+  webcamsErrors = [],
   webcamCount = 0,
   cameraTypeDefinitions = [],
   enabledCameraTypes = [],
@@ -151,6 +159,12 @@ export function ControlPanel({
             {webcamsEnabled && webcamsError && (
               <div className="error-message" role="alert">
                 ⚠️ Webcams unavailable
+              </div>
+            )}
+            {webcamsEnabled && !webcamsError && webcamsErrors.length > 0 && (
+              <div className="webcam-source-warning" role="status">
+                ⚠️ {webcamsErrors.map(e => SOURCE_LABELS[e.source] || e.source).join(', ')}{' '}
+                unavailable — other sources shown
               </div>
             )}
             {webcamsEnabled && cameraTypeDefinitions.length > 0 && (

--- a/src/components/PrivacyNotice.jsx
+++ b/src/components/PrivacyNotice.jsx
@@ -30,7 +30,7 @@ export function PrivacyNotice() {
           >
             OpenStreetMap
           </a>
-          . Webcam images:{' '}
+          . Webcam data:{' '}
           <a
             href="https://www.trafikverket.se/"
             target="_blank"
@@ -38,8 +38,16 @@ export function PrivacyNotice() {
           >
             Trafikverket
           </a>{' '}
-          (hotlinked stills, fetched only when the Webcams layer is enabled).
-          This site stores no tracking cookies.
+          (hotlinked stills, fetched only when the Webcams layer is enabled),{' '}
+          <a
+            href="https://www.windy.com/webcams"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Windy
+          </a>{' '}
+          and a curated webcam catalogue (camera listings and links only — no
+          media is fetched from them). This site stores no tracking cookies.
         </p>
         <button
           type="button"

--- a/src/components/PrivacyNotice.test.jsx
+++ b/src/components/PrivacyNotice.test.jsx
@@ -19,4 +19,18 @@ describe('PrivacyNotice', () => {
     expect(screen.getByText(/Trafiklab/i)).toBeTruthy();
     expect(screen.getByText(/OpenStreetMap/i)).toBeTruthy();
   });
+
+  it('names every webcam data source: Windy and the curated catalogue', () => {
+    render(<PrivacyNotice />);
+
+    expect(screen.getByText(/Windy/i)).toBeTruthy();
+    expect(screen.getByText(/curated webcam catalogue/i)).toBeTruthy();
+  });
+
+  it('reappears for users who acknowledged an older notice version (re-disclosure)', () => {
+    window.localStorage.setItem('rtt-privacy-notice-v2', '1');
+    render(<PrivacyNotice />);
+
+    expect(screen.getByText(/Windy/i)).toBeTruthy();
+  });
 });

--- a/src/hooks/useNoticeAcknowledgement.js
+++ b/src/hooks/useNoticeAcknowledgement.js
@@ -2,7 +2,9 @@ import { useCallback, useState } from 'react';
 
 // Bumped from v1 → v2 to re-disclose every returning user once after
 // Trafikverket was added as a third-party webcam image source (ADR 0001).
-const STORAGE_KEY = 'rtt-privacy-notice-v2';
+// Bumped v2 → v3 when Windy and the curated webcam catalogue were added
+// as webcam data sources — the notice must name every active source.
+const STORAGE_KEY = 'rtt-privacy-notice-v3';
 
 function readAcknowledged() {
   try {

--- a/src/hooks/useWebcams.js
+++ b/src/hooks/useWebcams.js
@@ -10,13 +10,23 @@ import { fetchCameras } from '../services/webcams';
  * `enabled` becomes true and reused for the rest of the session; toggling
  * off-then-on does NOT trigger a refetch.
  *
+ * Exception: a fetch that yields zero cameras (every source failed or threw)
+ * is not cached — the next off→on toggle retries, so a transient outage
+ * doesn't lock the layer empty for the whole session.
+ *
+ * `errors` carries per-source failures ({ source, message }) even when other
+ * sources delivered cameras, so partial outages are visible. `error` stays a
+ * summary string for the all-sources-failed case only.
+ *
  * @param {boolean} enabled
  */
 export function useWebcams(enabled) {
   const [cameras, setCameras] = useState([]);
   const [error, setError] = useState(null);
+  const [errors, setErrors] = useState([]);
   const [loading, setLoading] = useState(false);
   const fetchedRef = useRef(false);
+  const inFlightRef = useRef(false);
   const aliveRef = useRef(true);
 
   useEffect(() => {
@@ -27,30 +37,35 @@ export function useWebcams(enabled) {
   }, []);
 
   useEffect(() => {
-    if (!enabled || fetchedRef.current) return;
-    fetchedRef.current = true;
+    if (!enabled || fetchedRef.current || inFlightRef.current) return;
+    inFlightRef.current = true;
     setLoading(true);
 
     (async () => {
       try {
-        const { cameras: cams, errors } = await fetchCameras();
+        const { cameras: cams, errors: errs } = await fetchCameras();
         if (!aliveRef.current) return;
         setCameras(cams);
-        if (cams.length === 0 && errors.length > 0) {
-          const summary = errors.map(e => `${e.source}: ${e.message}`).join('; ');
+        setErrors(errs);
+        if (cams.length === 0 && errs.length > 0) {
+          const summary = errs.map(e => `${e.source}: ${e.message}`).join('; ');
           setError(summary);
+          // Total failure — leave fetchedRef false so the next enable retries.
         } else {
           setError(null);
+          fetchedRef.current = true;
         }
       } catch (e) {
         if (!aliveRef.current) return;
         setCameras([]);
+        setErrors([]);
         setError(e?.message || String(e));
       } finally {
+        inFlightRef.current = false;
         if (aliveRef.current) setLoading(false);
       }
     })();
   }, [enabled]);
 
-  return { cameras, error, loading };
+  return { cameras, error, errors, loading };
 }

--- a/src/hooks/useWebcams.test.js
+++ b/src/hooks/useWebcams.test.js
@@ -94,4 +94,53 @@ describe('useWebcams', () => {
     expect(result.current.cameras).toEqual([]);
     expect(result.current.error).toMatch(/boom/i);
   });
+
+  it('exposes per-source errors even when other sources delivered cameras (partial failure)', async () => {
+    service.fetchCameras.mockResolvedValueOnce({
+      cameras: SAMPLE,
+      errors: [{ source: 'trafikverket', message: 'HTTP 503' }],
+    });
+    const { result } = renderHook(() => useWebcams(true));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.cameras).toEqual(SAMPLE);
+    expect(result.current.error).toBeNull();
+    expect(result.current.errors).toEqual([
+      { source: 'trafikverket', message: 'HTTP 503' },
+    ]);
+  });
+
+  it('retries on next enable after a total failure (transient outage does not lock the session)', async () => {
+    service.fetchCameras.mockResolvedValueOnce({
+      cameras: [],
+      errors: [{ source: 'trafikverket', message: 'network down' }],
+    });
+    const { result, rerender } = renderHook(({ enabled }) => useWebcams(enabled), {
+      initialProps: { enabled: true },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toMatch(/network down/i);
+    expect(service.fetchCameras).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.cameras).toEqual(SAMPLE));
+    expect(service.fetchCameras).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not retry after a partial success — the session cache holds', async () => {
+    service.fetchCameras.mockResolvedValueOnce({
+      cameras: SAMPLE,
+      errors: [{ source: 'windy', message: 'HTTP 403' }],
+    });
+    const { result, rerender } = renderHook(({ enabled }) => useWebcams(enabled), {
+      initialProps: { enabled: true },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await new Promise(r => setTimeout(r, 10));
+    expect(service.fetchCameras).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/services/webcamPopup.js
+++ b/src/services/webcamPopup.js
@@ -16,6 +16,29 @@ function escapeHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
+// URL allowlist: only absolute http(s) URLs may reach href/src attributes.
+// HTML-escaping alone leaves javascript:/data: schemes intact, so external
+// feed data could otherwise smuggle a script URL into a link.
+function safeUrl(url) {
+  if (!url) return '';
+  const s = String(url).trim();
+  return /^https?:\/\//i.test(s) ? s : '';
+}
+
+// Source link: an <a> when a safe page URL exists, otherwise the label as
+// plain text — never an anchor with an empty or unsafe href.
+function sourceLink(pageUrl, label, style) {
+  const href = safeUrl(pageUrl);
+  const text = escapeHtml(label);
+  if (!href) return `<span style="${style}">${text}</span>`;
+  return `<a
+            href="${escapeHtml(href)}"
+            target="_blank"
+            rel="noopener noreferrer"
+            style="${style}"
+          >${text}</a>`;
+}
+
 function formatCaptureTime(iso) {
   if (!iso) return '';
   try {
@@ -49,7 +72,7 @@ export function cacheBustImageUrl(url, token) {
  *   a cache-busted URL on refresh without mutating the Camera).
  */
 export function cameraPopupImageContent(camera, options = {}) {
-  const src = options.imageUrl ?? camera.imageUrl ?? '';
+  const src = safeUrl(options.imageUrl ?? camera.imageUrl ?? '');
   const altText = camera.name ? `Webcam: ${camera.name}` : 'Webcam';
   const time = formatCaptureTime(camera.lastUpdated);
   const pageUrl = camera.pageUrl || camera.imageUrl || '';
@@ -71,12 +94,7 @@ export function cameraPopupImageContent(camera, options = {}) {
             data-webcam-refresh
             style="font-size: 12px; padding: 4px 8px; cursor: pointer;"
           >Refresh</button>
-          <a
-            href="${escapeHtml(pageUrl)}"
-            target="_blank"
-            rel="noopener noreferrer"
-            style="font-size: 12px; color: #2c3e50;"
-          >${escapeHtml(camera.attribution || 'Source')}</a>
+          ${sourceLink(pageUrl, camera.attribution || 'Source', 'font-size: 12px; color: #2c3e50;')}
         </div>
       </div>
     </div>
@@ -101,12 +119,7 @@ export function cameraPopupLinkoutContent(camera) {
           ${escapeHtml(attribution)}
         </div>
         <div style="margin-top: 8px;">
-          <a
-            href="${escapeHtml(pageUrl)}"
-            target="_blank"
-            rel="noopener noreferrer"
-            style="font-size: 13px; color: #2c3e50; font-weight: 600;"
-          >View at source ↗</a>
+          ${sourceLink(pageUrl, 'View at source ↗', 'font-size: 13px; color: #2c3e50; font-weight: 600;')}
         </div>
       </div>
     </div>
@@ -128,12 +141,7 @@ export function cameraPopupErrorContent(camera) {
       <div style="padding: 6px 2px 0;">
         <strong style="font-size: 14px;">${escapeHtml(camera.name || '')}</strong>
         <div style="margin-top: 6px;">
-          <a
-            href="${escapeHtml(pageUrl)}"
-            target="_blank"
-            rel="noopener noreferrer"
-            style="font-size: 12px; color: #2c3e50;"
-          >View at ${escapeHtml(camera.attribution || 'source')}</a>
+          ${sourceLink(pageUrl, `View at ${camera.attribution || 'source'}`, 'font-size: 12px; color: #2c3e50;')}
         </div>
       </div>
     </div>

--- a/src/services/webcamPopup.test.js
+++ b/src/services/webcamPopup.test.js
@@ -76,6 +76,27 @@ describe('cameraPopupImageContent', () => {
     expect(html).not.toMatch(/<img\s+src=x\s+onerror=/);
     expect(html).toContain('&lt;script&gt;');
   });
+
+  it('drops javascript: pageUrl — attribution renders as text, not a link', () => {
+    const hostile = { ...SAMPLE_CAMERA, pageUrl: 'javascript:alert(1)' };
+    const html = cameraPopupImageContent(hostile);
+    expect(html).not.toContain('javascript:');
+    expect(html).not.toMatch(/<a[^>]*href/);
+    expect(html).toContain('Trafikverket');
+  });
+
+  it('drops data: imageUrl — img src is emptied', () => {
+    const hostile = { ...SAMPLE_CAMERA, imageUrl: 'data:text/html,<script>alert(1)</script>', pageUrl: 'https://example.test/cam/001.html' };
+    const html = cameraPopupImageContent(hostile);
+    expect(html).not.toContain('data:text/html');
+    expect(html).toMatch(/src=""/);
+  });
+
+  it('keeps https URLs intact through the allowlist', () => {
+    const html = cameraPopupImageContent(SAMPLE_CAMERA);
+    expect(html).toMatch(/src="https:\/\/example\.test\/cam\/001\.jpg"/);
+    expect(html).toMatch(/<a[^>]*href="https:\/\/example\.test\/cam\/001\.html"[^>]*>/);
+  });
 });
 
 describe('cameraPopupErrorContent', () => {
@@ -157,6 +178,13 @@ describe('cameraPopupLinkoutContent', () => {
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).not.toMatch(/<img\s+src=x\s+onerror=/);
     expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('drops javascript: pageUrl — no anchor is rendered', () => {
+    const hostile = { ...LINKOUT_CAMERA, pageUrl: 'javascript:alert(1)' };
+    const html = cameraPopupLinkoutContent(hostile);
+    expect(html).not.toContain('javascript:');
+    expect(html).not.toMatch(/<a[^>]*href/);
   });
 });
 

--- a/src/services/webcams.js
+++ b/src/services/webcams.js
@@ -69,7 +69,10 @@ export function normalizeTrafikverketCamera(raw) {
 async function fetchTrafikverketCameras() {
   const apiKey = import.meta.env?.VITE_TRAFIKVERKET_API_KEY;
   if (!apiKey) {
-    return { cameras: [], error: 'missing VITE_TRAFIKVERKET_API_KEY' };
+    // Absent source, not a failure: keyless is a legitimate configuration,
+    // mirroring the Windy adapter. Only configured-but-unreachable sources
+    // surface errors.
+    return { cameras: [], error: null };
   }
   try {
     const response = await fetch(TRAFIKVERKET_ENDPOINT, {

--- a/src/services/webcams.test.js
+++ b/src/services/webcams.test.js
@@ -209,6 +209,19 @@ describe('webcams service — fetchCameras', () => {
     // Trafikverket failure surfaces; the curated source still rendered.
     expect(errors.some(e => e.source === 'trafikverket')).toBe(true);
   });
+
+  it('missing VITE_TRAFIKVERKET_API_KEY → absent source: zero cameras, no error, no fetch', async () => {
+    vi.unstubAllEnvs();
+    // Trafikverket key intentionally absent — keyless is configuration, not failure.
+
+    const { cameras, errors } = await fetchCameras();
+
+    expect(cameras.filter(c => c.source === 'trafikverket')).toEqual([]);
+    expect(errors.some(e => e.source === 'trafikverket')).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+    // The curated source still ships.
+    expect(cameras.filter(c => c.source === 'webcamcollections').length).toBeGreaterThan(0);
+  });
 });
 
 describe('webcams service — Windy adapter', () => {


### PR DESCRIPTION
## Summary

Implements the four findings from the webcam-layer code review (develop@af9e344):

- **Partial source failures surfaced** (P2): `useWebcams` now exposes a per-source `errors` list; the Layers section shows "⚠️ Trafikverket unavailable — other sources shown" when one source fails but others deliver. Previously a failed source was silent as soon as any camera rendered.
- **Absent vs failed source**: missing `VITE_TRAFIKVERKET_API_KEY` is now an *absent source* (zero cameras, no error — mirroring the Windy adapter) instead of a failure. The distinction is documented in CONTEXT.md (new glossary entry: *Source absence vs source failure*) and `.env.example`.
- **Retry after total failure** (P3): a fetch yielding zero cameras no longer locks the session — the next layer enable retries. Partial successes stay cached per the fetch-once contract.
- **URL scheme allowlist** (P2): popup `href`/`src` only accept absolute http(s) URLs; `javascript:`/`data:` from feed data renders as plain text / empty src. Unsafe page URLs degrade the source link to a text label instead of an anchor.
- **Privacy Notice disclosure** (P2): the notice now names all three webcam data sources — Trafikverket (hotlinked stills), Windy and the curated catalogue (links only). Notice storage key bumped v2→v3 so every returning user is re-disclosed once, per ADR 0001.

## Test plan

- `npm test`: 14 files, **189 tests pass** (+10 new: partial-error exposure, retry-after-failure, session-cache-on-partial, absent-source, javascript:/data: URL rejection, https passthrough, notice source naming, v2→v3 re-disclosure)
- `npm run build`: passes, sourcemaps off
- **Security analysis**: XSS surface reduced (URL allowlist); feed data remains HTML-escaped; no secrets in source; Trafikverket/Windy keys inline in bundle by design (`VITE_` client keys, documented). `npm audit --omit=dev`: 9 pre-existing vulnerabilities (1 critical, protobufjs via gtfs-realtime-bindings) — untouched by this diff, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)