### PR TITLE
perf: reduce GTFS entity parse allocations

### DIFF
--- a/src/services/trafiklab.js
+++ b/src/services/trafiklab.js
@@ -56,41 +56,43 @@ async function fetchSingleOperator(slug, tripMapping, apiKey) {
   const timestamp = feed.header.timestamp;
   const dataTimestamp = timestamp != null ? Number(timestamp) : null;
 
-  const vehicles = feed.entity
-    .filter(entity => entity.vehicle && entity.vehicle.position)
-    .map(entity => {
-      const v = entity.vehicle;
-      const routeId = v.trip?.routeId;
-      const tripId = v.trip?.tripId;
+  const vehicles = [];
+  for (const entity of feed.entity) {
+    if (!entity.vehicle || !entity.vehicle.position) continue;
+    const v = entity.vehicle;
+    const routeId = v.trip?.routeId;
+    const tripId = v.trip?.tripId;
 
-      let mode = 'unknown';
-      let line = v.vehicle?.label || routeId || 'Unknown';
+    let mode = 'unknown';
+    let line = v.vehicle?.label || routeId || 'Unknown';
 
-      if (tripId && tripMapping) {
-        const tripInfo = tripMapping[tripId];
-        if (tripInfo) {
-          if (tripInfo.line) line = tripInfo.line;
-          mode = routeTypeToMode(tripInfo.routeType);
-        }
+    if (tripId && tripMapping) {
+      const tripInfo = tripMapping[tripId];
+      if (tripInfo) {
+        if (tripInfo.line) line = tripInfo.line;
+        mode = routeTypeToMode(tripInfo.routeType);
       }
+    }
 
-      return {
-        id: `${slug}:${v.vehicle?.id || entity.id}`,
-        operator: slug,
-        routeId,
-        line,
-        lineName: '',
-        mode,
-        latitude: v.position.latitude,
-        longitude: v.position.longitude,
-        bearing: v.position.bearing || 0,
-        speed: v.position.speed || 0,
-        timestamp: v.timestamp || timestamp,
-        tripId,
-        direction: v.trip?.directionId
-      };
-    })
-    .filter(v => v.latitude && v.longitude);
+    const vehicle = {
+      id: `${slug}:${v.vehicle?.id || entity.id}`,
+      operator: slug,
+      routeId,
+      line,
+      lineName: '',
+      mode,
+      latitude: v.position.latitude,
+      longitude: v.position.longitude,
+      bearing: v.position.bearing || 0,
+      speed: v.position.speed || 0,
+      timestamp: v.timestamp || timestamp,
+      tripId,
+      direction: v.trip?.directionId
+    };
+    if (vehicle.latitude && vehicle.longitude) {
+      vehicles.push(vehicle);
+    }
+  }
 
   return { vehicles, dataTimestamp };
 }


### PR DESCRIPTION
## Summary
Single change in hot path: src/services/trafiklab.js now parses GTFS entities in one pass (for..of) instead of filter().map().filter().

Why this one first: highest impact + lowest effort. It runs every poll for every active operator, and this removes two intermediate arrays plus callback churn without changing behavior.

## 10 performance improvement candidates
| # | Title | Location | Why it helps | Impact | Effort | Confidence |
|---|---|---|---|---|---|---|
| 1 | **Single-pass GTFS entity parsing** (**implemented**) | src/services/trafiklab.js (fetchSingleOperator) | Removes filter→map→filter allocations/callbacks in hottest polling path | **High** | **Low** | **High** |
| 2 | Index snapshots by vehicle id in anomaly scan | src/services/anomalyRules.js (detectStationaryAnomalies) | Avoids repeated Array.find per vehicle per snapshot (cuts quadratic scans) | High | Med | High |
| 3 | Precompute operator feed series once per poll | src/services/feedOutageRules.js | Avoids repeated find scans per operator across all snapshots | Med | Med | High |
| 4 | Avoid full-array filter on every buffer append | src/services/observationBuffer.js (append) | Replaces snapshots.filter(...) per append with incremental trimming | Med | Low | High |
| 5 | Skip icon rebuild when marker visual state unchanged | src/services/vehicleAdapter.js (onUpdate) | Prevents costly setIcon/divIcon rebuilds for unchanged markers | High | Med | Med |
| 6 | Build currentIds without items.map temp array | src/services/markerCollection.js (update) | Removes per-update intermediate array allocation on large marker sets | Med | Low | High |
| 7 | Use Set for enabled mode membership | src/hooks/useFilterSelection.js | Replaces repeated includes in large loops with O(1) membership checks | Med | Low | High |
| 8 | Memoize panel stats derivation | src/components/ControlPanel.jsx | Prevents repeated vehicles.reduce(...) work on unrelated UI re-renders | Low | Low | High |
| 9 | Stabilize highlight dependency keying | src/components/Map.jsx | Avoids join(',') string build + unnecessary marker refresh cycles | Low | Low | Med |
| 10 | Defer expensive popup content formatting until open | src/services/vehicleAdapter.js | Avoids building popup HTML/time strings for markers users never open | Med | Med | Med |

## Why #1 was implemented
- Highest call frequency (every GTFS poll, all visible operators).
- Minimal surface area (single module, no interface changes).
- Preserves behavior/output shape exactly.

## Validation
- npm test
- npm run build
- Security pass: npm audit and secret-pattern scan in src/dist/public (no key leak findings in bundle output).
