### PR TITLE
perf: memoize control panel stats

### DIFF
--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -48,12 +48,14 @@ export function ControlPanel({
   const [lineFilterExpanded, setLineFilterExpanded] = useState(false);
   const [lineSearch, setLineSearch] = useState('');
 
-  const stats = vehicles.reduce((acc, v) => {
-    acc[v.mode] = (acc[v.mode] || 0) + 1;
-    return acc;
-  }, {});
+  const { stats, totalVisible } = useMemo(() => {
+    const stats = vehicles.reduce((acc, v) => {
+      acc[v.mode] = (acc[v.mode] || 0) + 1;
+      return acc;
+    }, {});
 
-  const totalVisible = vehicles.length;
+    return { stats, totalVisible: vehicles.length };
+  }, [vehicles]);
 
   const filteredLineOptions = useMemo(() => {
     if (!lineSearch.trim()) return availableLines;

--- a/src/components/ControlPanel.test.jsx
+++ b/src/components/ControlPanel.test.jsx
@@ -12,6 +12,29 @@ const baseProps = {
   enabledModes: ['bus'],
 };
 
+describe('ControlPanel — Vehicle stats', () => {
+  it('memoizes mode counts across unrelated panel state renders', () => {
+    const vehicles = [
+      { mode: 'bus' },
+      { mode: 'bus' },
+      { mode: 'train' },
+    ];
+    const reduceSpy = vi.spyOn(vehicles, 'reduce');
+
+    render(<ControlPanel {...baseProps} vehicles={vehicles} enabledModes={['bus', 'train']} />);
+
+    expect(reduceSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Total vehicles:').nextSibling.textContent).toBe('3');
+    expect(screen.getByText('(2)')).toBeTruthy();
+    expect(screen.getByText('(1)')).toBeTruthy();
+
+    fireEvent.click(screen.getByTitle('Collapse'));
+    fireEvent.click(screen.getByTitle('Expand'));
+
+    expect(reduceSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('ControlPanel — Favourite star control', () => {
   it('renders a star control on each available-line chip', () => {
     render(<ControlPanel {...baseProps} />);


### PR DESCRIPTION
## Summary
- Memoizes `ControlPanel` vehicle stats derivation so unchanged `vehicles` input does not re-run mode count reduction on unrelated panel state renders.
- Keeps total and per-mode displayed counts unchanged.
- Adds a focused regression test covering the memoized same-vehicles render path.

Part of #127.
Closes #124.

## Performance benefit
Unrelated Control Panel renders, such as collapse/expand or other local panel state changes, now reuse the existing stats object while the `vehicles` array reference is unchanged. This avoids repeated O(n) vehicle scans outside polling/filter updates.

## Checks run
- `npm test -- src/components/ControlPanel.test.jsx` — passed (10 tests)
- `npm test` — passed (38 files, 474 tests)
- `npm run build` — passed; sourcemaps remain disabled/no `.map` output
- Security analysis — diff adds no `innerHTML`, popup, external feed rendering, API key, or secret paths; no package/lockfile changes; `.env` values scan skipped because no `.env` exists in this worktree
- `npm audit --audit-level=high` — reports existing dependency advisories, including one high in `undici`; no dependency changes in this PR, so no new audit findings introduced
