### PR TITLE
perf: build marker id set directly

### DIFF
--- a/src/services/markerCollection.js
+++ b/src/services/markerCollection.js
@@ -37,7 +37,8 @@ export function createMarkerCollection(layer, { createMarker = defaultCreateMark
     typeof layer.removeLayers === 'function' && typeof layer.addLayers === 'function';
 
   function update(items, adapter) {
-    const currentIds = new Set(items.map(item => item.id));
+    const currentIds = new Set();
+    items.forEach(item => currentIds.add(item.id));
 
     for (const [id, marker] of markers.entries()) {
       if (!currentIds.has(id)) {


### PR DESCRIPTION
## Summary
- Build markerCollection current marker id Set directly instead of allocating a temporary items.map(...) array.
- Preserves existing marker add/update/remove behavior; only changes the allocation pattern in update.

Closes #122

Part of #127.

## Performance benefit
Avoids one transient array allocation per marker collection update, reducing GC pressure in the hot marker update path while keeping the same Set membership semantics.

## Checks run
- npm test - 38 files / 473 tests passed
- npm run build - passed; sourcemaps remain disabled and no .map files emitted
- Security analysis - diff adds no innerHTML/popup/XSS paths, no external-data handling changes, no secret-like diff, Trafiklab key not found in dist (no-env-key locally), npm audit --audit-level=high reports existing dependency advisories (no dependency changes in this PR)
