### PR TITLE
perf: precompute operator feed series

### DIFF
--- a/src/services/feedOutageRules.js
+++ b/src/services/feedOutageRules.js
@@ -28,14 +28,21 @@ function watchedOperators(latest) {
   return new Set((latest.feeds ?? []).map((f) => f.operator));
 }
 
-/** The operator's feed outcome series in chronological order (only where present). */
-function feedSeries(snapshots, operator) {
-  const series = [];
+/** Feed outcome series per watched operator in chronological order (only where present). */
+function feedSeriesByOperator(snapshots, operators) {
+  const byOperator = new Map(Array.from(operators, (operator) => [operator, []]));
+
   for (const s of snapshots) {
-    const f = (s.feeds ?? []).find((x) => x.operator === operator);
-    if (f) series.push({ time: s.time, ...f });
+    const seenInSnapshot = new Set();
+    for (const f of (s.feeds ?? [])) {
+      if (seenInSnapshot.has(f.operator)) continue;
+      const series = byOperator.get(f.operator);
+      if (!series) continue;
+      series.push({ time: s.time, ...f });
+      seenInSnapshot.add(f.operator);
+    }
   }
-  return series;
+  return byOperator;
 }
 
 function detectFetchFailure(series, operator, now) {
@@ -114,10 +121,11 @@ function detectVehicleCollapse(series, operator, now) {
 export function detectFeedOutageAnomalies(snapshots, now) {
   if (!snapshots || snapshots.length === 0) return [];
   const latest = snapshots[snapshots.length - 1];
+  const watched = watchedOperators(latest);
+  const seriesByOperator = feedSeriesByOperator(snapshots, watched);
 
   const anomalies = [];
-  for (const operator of watchedOperators(latest)) {
-    const series = feedSeries(snapshots, operator);
+  for (const [operator, series] of seriesByOperator) {
     const fetchFailure = detectFetchFailure(series, operator, now);
     if (fetchFailure) anomalies.push(fetchFailure);
     const frozen = detectFrozenTimestamps(series, operator, now);

--- a/src/services/feedOutageRules.test.js
+++ b/src/services/feedOutageRules.test.js
@@ -152,5 +152,26 @@ describe('detectFeedOutageAnomalies', () => {
       const anomalies = detectFeedOutageAnomalies(snaps, 2 * MIN);
       expect(anomalies.some((a) => a.operator === 'ul')).toBe(false);
     });
+
+    it('preserves watched-operator order and first feed outcome per snapshot', () => {
+      const snaps = [
+        snap(0, [
+          feed({ operator: 'ul', ok: false }),
+          feed({ operator: 'ul', ok: true }),
+          feed({ operator: 'sl', ok: false }),
+          feed({ operator: 'sl', ok: true }),
+        ]),
+        snap(1 * MIN, [
+          feed({ operator: 'ul', ok: false }),
+          feed({ operator: 'sl', ok: false }),
+        ]),
+        snap(2 * MIN, [
+          feed({ operator: 'ul', ok: false }),
+          feed({ operator: 'sl', ok: false }),
+        ]),
+      ];
+
+      expect(detectFeedOutageAnomalies(snaps, 2 * MIN).map((a) => a.operator)).toEqual(['ul', 'sl']);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Precompute watched operator feed outcome series once per `detectFeedOutageAnomalies` cycle.
- Reuse those series across fetch-failure, frozen-timestamp, and vehicle-collapse checks instead of rescanning snapshots once per operator.
- Preserve existing anomaly shape/order and first feed outcome per snapshot semantics; added regression coverage for that behavior.

Closes #119.
Part of #127.

## Performance benefit
This changes feed outage detection from repeated `snapshots × watched operators` feed scans to a single pass over the snapshot feed history per cycle, reducing work as watched operator count/history length grow.

## Checks run
- `npm test` — passed
- `npm run build` — passed; no sourcemaps emitted
- Security analysis — diff adds no `innerHTML`/popup/feed-data rendering paths, no secret-like additions, no tracked `.env` changes, no local API key values available to scan (`.env` absent), no sourcemaps in `dist/`
- `npm audit --audit-level=high --json` — existing high transitive `undici` finding present; package files unchanged, so this PR adds no new dependency audit findings
- `git diff --check` — passed
- Old/new behavior comparison over 500 generated feed histories — matched
- Code review agent — no blocking findings

## Risk / notes
- Low risk: pure service refactor plus focused regression test.
- Does not touch `vehicleAdapter.js` or other coordinated performance issues.
