### PR TITLE
perf: stabilize highlight dependencies

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -9,6 +9,8 @@ import { createMarkerCollection } from '../services/markerCollection';
 import { createVehicleAdapter, FULL_MARKER_MIN_ZOOM } from '../services/vehicleAdapter';
 import { createWebcamAdapter } from '../services/webcamAdapter';
 
+const EMPTY_HIGHLIGHTED_VEHICLE_IDS = [];
+
 function haveSameOrderedIds(previousIds, nextIds) {
   if (previousIds.length !== nextIds.length) return false;
   for (let i = 0; i < previousIds.length; i += 1) {
@@ -17,29 +19,22 @@ function haveSameOrderedIds(previousIds, nextIds) {
   return true;
 }
 
-function useStableHighlightState(highlightedVehicleIds) {
-  const highlightStateRef = useRef({
-    ids: [],
-    idSet: new Set(),
-    version: 0,
-  });
-  const highlightState = highlightStateRef.current;
-
-  if (!haveSameOrderedIds(highlightState.ids, highlightedVehicleIds)) {
-    highlightState.ids = highlightedVehicleIds.slice();
-    highlightState.idSet = new Set(highlightedVehicleIds);
-    highlightState.version += 1;
-  }
-
-  return highlightStateRef;
+function createHighlightState(highlightedVehicleIds) {
+  return {
+    ids: highlightedVehicleIds.slice(),
+    idSet: new Set(highlightedVehicleIds),
+    vehicles: null,
+    mapZoom: null,
+  };
 }
 
-export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = [] }) {
+export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = EMPTY_HIGHLIGHTED_VEHICLE_IDS }) {
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
   const vehicleCollectionRef = useRef(null);
   // Highlight set is read live by the adapter so selection changes are reflected.
-  const highlightStateRef = useStableHighlightState(highlightedVehicleIds);
+  const [initialHighlightState] = useState(() => createHighlightState(highlightedVehicleIds));
+  const highlightStateRef = useRef(initialHighlightState);
   // Current zoom, read live by the adapter; mapZoom state re-triggers the
   // marker-update effect so existing markers swap compact/full icons on zoom.
   const zoomRef = useRef(zoom);
@@ -151,12 +146,25 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
     }
   }, [center, zoom]);
 
-  // Update vehicle markers via the marker-collection module. Re-runs when the
-  // highlight set or zoom changes too, so existing markers refresh their icon.
-  const highlightVersion = highlightStateRef.current.version;
+  // Update vehicle markers via the marker-collection module. Runs after render
+  // so highlight bookkeeping stays out of render; the equality gate prevents
+  // marker churn unless vehicles, ordered highlights, or zoom actually changed.
   useEffect(() => {
+    const highlightState = highlightStateRef.current;
+    const highlightsChanged = !haveSameOrderedIds(highlightState.ids, highlightedVehicleIds);
+    if (highlightsChanged) {
+      highlightState.ids = highlightedVehicleIds.slice();
+      highlightState.idSet = new Set(highlightedVehicleIds);
+    }
+
+    const vehiclesChanged = highlightState.vehicles !== vehicles;
+    const zoomChanged = highlightState.mapZoom !== mapZoom;
+    if (!vehiclesChanged && !highlightsChanged && !zoomChanged) return;
+
+    highlightState.vehicles = vehicles;
+    highlightState.mapZoom = mapZoom;
     vehicleCollectionRef.current?.update(vehicles, vehicleAdapterRef.current);
-  }, [vehicles, highlightVersion, mapZoom]);
+  });
 
   // Update webcam markers via the marker-collection module (webcam adapter).
   useEffect(() => {
@@ -174,5 +182,3 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
     />
   );
 }
-
-

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -9,20 +9,44 @@ import { createMarkerCollection } from '../services/markerCollection';
 import { createVehicleAdapter, FULL_MARKER_MIN_ZOOM } from '../services/vehicleAdapter';
 import { createWebcamAdapter } from '../services/webcamAdapter';
 
+function haveSameOrderedIds(previousIds, nextIds) {
+  if (previousIds.length !== nextIds.length) return false;
+  for (let i = 0; i < previousIds.length; i += 1) {
+    if (previousIds[i] !== nextIds[i]) return false;
+  }
+  return true;
+}
+
+function useStableHighlightState(highlightedVehicleIds) {
+  const highlightStateRef = useRef({
+    ids: [],
+    idSet: new Set(),
+    version: 0,
+  });
+  const highlightState = highlightStateRef.current;
+
+  if (!haveSameOrderedIds(highlightState.ids, highlightedVehicleIds)) {
+    highlightState.ids = highlightedVehicleIds.slice();
+    highlightState.idSet = new Set(highlightedVehicleIds);
+    highlightState.version += 1;
+  }
+
+  return highlightStateRef;
+}
+
 export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = [] }) {
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
   const vehicleCollectionRef = useRef(null);
   // Highlight set is read live by the adapter so selection changes are reflected.
-  const highlightRef = useRef(new Set());
-  highlightRef.current = new Set(highlightedVehicleIds);
+  const highlightStateRef = useStableHighlightState(highlightedVehicleIds);
   // Current zoom, read live by the adapter; mapZoom state re-triggers the
   // marker-update effect so existing markers swap compact/full icons on zoom.
   const zoomRef = useRef(zoom);
   const [mapZoom, setMapZoom] = useState(zoom);
   const vehicleAdapterRef = useRef(
     createVehicleAdapter({
-      isHighlighted: (id) => highlightRef.current.has(id),
+      isHighlighted: (id) => highlightStateRef.current.idSet.has(id),
       getZoom: () => zoomRef.current,
     }),
   );
@@ -129,10 +153,10 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
 
   // Update vehicle markers via the marker-collection module. Re-runs when the
   // highlight set or zoom changes too, so existing markers refresh their icon.
-  const highlightKey = highlightedVehicleIds.join(',');
+  const highlightVersion = highlightStateRef.current.version;
   useEffect(() => {
     vehicleCollectionRef.current?.update(vehicles, vehicleAdapterRef.current);
-  }, [vehicles, highlightKey, mapZoom]);
+  }, [vehicles, highlightVersion, mapZoom]);
 
   // Update webcam markers via the marker-collection module (webcam adapter).
   useEffect(() => {
@@ -150,6 +174,5 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
     />
   );
 }
-
 
 


### PR DESCRIPTION
## Summary
- Closes #125
- Part of coordinated performance workstream #127
- Replaces the per-render `highlightedVehicleIds.join(',')` dependency key in `Map.jsx` with ordered highlight comparison inside the marker-update effect.
- Keeps marker refreshes for vehicle data, zoom changes, and every ordered highlight-id change, while avoiding repeated string allocation/comparison churn when highlights are stable.
- Follow-up: addressed review feedback by keeping highlight bookkeeping out of render; the effect now gates marker collection updates on actual vehicle, ordered-highlight, or zoom changes.

## Checks run
- `npm test` — passed
- `npm run build` — passed; no source maps generated in `dist/`
- `git diff --check` — passed
- Code-review agent — no significant issues found after follow-up
- Security analysis:
  - Diff adds no `innerHTML`, popup, external feed-data rendering, env, token, secret, or API-key paths.
  - Built bundle check found no local `VITE_TRAFIKLAB_API_KEY` value because `.env` is not present in this worktree.
  - `npm audit --audit-level=high` reports an existing high-severity `undici` advisory plus lower-severity transitive advisories; this PR changes no dependencies.

## Risk / notes
- Low risk: change is limited to highlight dependency bookkeeping in `src/components/Map.jsx`.
- Order-sensitive highlight updates are preserved while avoiding render-time ref mutation and avoiding marker refresh churn for unchanged highlights.
