### PR TITLE
perf: index snapshots by vehicle id

### DIFF
--- a/src/services/anomalyRules.js
+++ b/src/services/anomalyRules.js
@@ -50,6 +50,25 @@ function indexVehiclesById(vehicles) {
   return byId;
 }
 
+function createVehicleLookup(snapshots) {
+  const indexedSnapshots = new Map();
+  const linearLookupSnapshots = new Set();
+
+  return (snapshotIndex, vehicleId) => {
+    const indexed = indexedSnapshots.get(snapshotIndex);
+    if (indexed) return indexed.get(vehicleId);
+
+    if (!linearLookupSnapshots.has(snapshotIndex)) {
+      linearLookupSnapshots.add(snapshotIndex);
+      return snapshots[snapshotIndex].vehicles.find((x) => x.id === vehicleId);
+    }
+
+    const byId = indexVehiclesById(snapshots[snapshotIndex].vehicles);
+    indexedSnapshots.set(snapshotIndex, byId);
+    return byId.get(vehicleId);
+  };
+}
+
 /**
  * Learn Dwell spots from the observation history. A vehicle observed within the
  * displacement threshold of its own previous observation is "standing" at that
@@ -145,7 +164,7 @@ export function detectStationaryAnomalies(snapshots, now, { dwellSpots = [] } = 
   if (!snapshots || snapshots.length === 0) return [];
 
   const latest = snapshots[snapshots.length - 1];
-  const vehiclesBySnapshot = snapshots.map((snapshot) => indexVehiclesById(snapshot.vehicles));
+  const vehicleAt = createVehicleLookup(snapshots);
   const anomalies = [];
 
   for (const v of latest.vehicles) {
@@ -154,7 +173,7 @@ export function detectStationaryAnomalies(snapshots, now, { dwellSpots = [] } = 
 
     let startedAt = latest.time;
     for (let i = snapshots.length - 2; i >= 0; i--) {
-      const prev = vehiclesBySnapshot[i].get(v.id);
+      const prev = vehicleAt(i, v.id);
       if (!prev || !onActiveTrip(prev) || !hasCoords(prev)) break;
       if (distanceMeters(v.latitude, v.longitude, prev.latitude, prev.longitude) > DISPLACEMENT_THRESHOLD_M) {
         break;

--- a/src/services/anomalyRules.js
+++ b/src/services/anomalyRules.js
@@ -40,6 +40,16 @@ function onActiveTrip(x) {
   return Boolean(x && x.tripId);
 }
 
+function indexVehiclesById(vehicles) {
+  const byId = new Map();
+  for (const vehicle of vehicles) {
+    if (!byId.has(vehicle.id)) {
+      byId.set(vehicle.id, vehicle);
+    }
+  }
+  return byId;
+}
+
 /**
  * Learn Dwell spots from the observation history. A vehicle observed within the
  * displacement threshold of its own previous observation is "standing" at that
@@ -135,6 +145,7 @@ export function detectStationaryAnomalies(snapshots, now, { dwellSpots = [] } = 
   if (!snapshots || snapshots.length === 0) return [];
 
   const latest = snapshots[snapshots.length - 1];
+  const vehiclesBySnapshot = snapshots.map((snapshot) => indexVehiclesById(snapshot.vehicles));
   const anomalies = [];
 
   for (const v of latest.vehicles) {
@@ -143,7 +154,7 @@ export function detectStationaryAnomalies(snapshots, now, { dwellSpots = [] } = 
 
     let startedAt = latest.time;
     for (let i = snapshots.length - 2; i >= 0; i--) {
-      const prev = snapshots[i].vehicles.find((x) => x.id === v.id);
+      const prev = vehiclesBySnapshot[i].get(v.id);
       if (!prev || !onActiveTrip(prev) || !hasCoords(prev)) break;
       if (distanceMeters(v.latitude, v.longitude, prev.latitude, prev.longitude) > DISPLACEMENT_THRESHOLD_M) {
         break;

--- a/src/services/anomalyRules.test.js
+++ b/src/services/anomalyRules.test.js
@@ -90,6 +90,30 @@ describe('detectStationaryAnomalies — stationary on active trip', () => {
     });
     expect(detectStationaryAnomalies(snaps, 6 * MIN)).toHaveLength(1);
   });
+
+  it('preserves first-match semantics for duplicate vehicle ids after indexing', () => {
+    const dupStationary = vehicle({ id: 'dup' });
+    const dupMoved = vehicle({ id: 'dup', latitude: 59.4 });
+    const snaps = [
+      { time: 0, vehicles: [vehicle({ id: 'first' }), vehicle({ id: 'second' }), dupStationary] },
+      {
+        time: 3 * MIN,
+        vehicles: [
+          vehicle({ id: 'first' }),
+          vehicle({ id: 'second' }),
+          dupMoved,
+          dupStationary,
+        ],
+      },
+      {
+        time: 6 * MIN,
+        vehicles: [vehicle({ id: 'first' }), vehicle({ id: 'second' }), dupStationary],
+      },
+    ];
+
+    const vehicleIds = detectStationaryAnomalies(snaps, 6 * MIN).map((a) => a.vehicleId);
+    expect(vehicleIds).toEqual(['first', 'second']);
+  });
 });
 
 // Two locations: A is a habitual stop (terminal), B is far away (~8 km).


### PR DESCRIPTION
## Summary
- Lazily index historical snapshot vehicles by `id` inside `detectStationaryAnomalies`.
- Preserve the original `Array.find` path for snapshots touched only once, then build a first-wins `Map` only on repeated lookup for that snapshot.
- Add coverage for duplicate vehicle ids so indexed lookup preserves `Array.find` first-match semantics and anomaly output shape.
- Part of coordinated performance workstream #127.

Closes #118

## Performance benefit
The first PR version eagerly indexed every snapshot on every detection run, which could regress the common early-exit path. This update keeps early-exit behavior lazy: moving vehicles that break after one previous snapshot no longer force indexing of the full 30-minute observation buffer.

Local throwaway benchmark, 900 snapshots x 1600 vehicles:
- moving/early-break: eager-current 70.7ms; lazy-updated 0.9ms
- stationary/worst-case: old linear find 3535.1ms; eager-current 240.0ms; lazy-updated 307.0ms

So the Gemini blocking finding is resolved: indexes are created only for snapshots with repeated lookups, not unconditionally for the whole buffer.

## Checks run
- `npm test -- --run src/services/anomalyRules.test.js` — passed (14 tests)
- `npm test` — passed
- `npm run build` — passed; sourcemaps remain off (`find dist -name '*.map'` => 0)
- Security analysis — diff adds no API key, feed-data rendering, popup, `innerHTML`, or sanitization paths; `.env` is not tracked/modified; local secret-value grep found no bundle exposure
- `npm audit --audit-level=high` — reports existing dependency advisories, including high `undici`; package files unchanged and no new dependencies added
- Code review agent — no significant issues found

## Risk / notes
Low risk: pure-service lookup change, isolated to stationary anomaly detection. Duplicate-id behavior remains first-match/first-wins to match `Array.find`; anomaly output shape unchanged.