### PR TITLE
perf: avoid unnecessary vehicle marker work

### DIFF
--- a/src/services/markerCollection.js
+++ b/src/services/markerCollection.js
@@ -23,7 +23,7 @@ function defaultCreateMarker(latLng, options) {
  * Adapter interface (passed per update call):
  *   toLatLng(item)  → [lat, lng] | null  (null skips the item)
  *   toIcon(item)    → Leaflet icon
- *   toPopup(item)   → HTML string
+ *   toPopup(item)   → HTML string or Leaflet popup content function
  *   onUpdate?       → (marker, item) called when updating an existing marker
  *                     (default: setLatLng + setPopupContent)
  *   shouldReadd?    → (marker, item) → boolean; when true and the layer is a

--- a/src/services/vehicleAdapter.js
+++ b/src/services/vehicleAdapter.js
@@ -30,6 +30,34 @@ export const FULL_MARKER_MIN_ZOOM = 12;
  *   render compact. Default: always full-size.
  */
 export function createVehicleAdapter({ isHighlighted = () => false, getZoom = () => FULL_MARKER_MIN_ZOOM } = {}) {
+  const markerVehicles = new WeakMap();
+  const markerVisualStateKeys = new WeakMap();
+
+  function visualStateFor(vehicle) {
+    const color = MODE_COLORS[vehicle.mode] || MODE_COLORS.unknown;
+    const icon = MODE_ICONS[vehicle.mode] || MODE_ICONS.unknown;
+    const highlighted = isHighlighted(vehicle.id);
+    const compact = !highlighted && getZoom() < FULL_MARKER_MIN_ZOOM;
+    const label = vehicle.line?.length <= 3 ? ['line', String(vehicle.line ?? '')] : ['icon', icon];
+
+    return {
+      color,
+      icon,
+      highlighted,
+      compact,
+      key: JSON.stringify([compact, color, highlighted, label]),
+    };
+  }
+
+  function lazyPopupContent(vehicle) {
+    return (source) => vehiclePopupContent(markerVehicles.get(source) ?? vehicle);
+  }
+
+  function updateOpenPopup(marker, vehicle) {
+    if (typeof marker.isPopupOpen !== 'function' || !marker.isPopupOpen()) return;
+    if (typeof marker.setPopupContent === 'function') marker.setPopupContent(lazyPopupContent(vehicle));
+  }
+
   function buildCompactIcon(color) {
     return L.divIcon({
       className: 'vehicle-marker vehicle-marker--compact',
@@ -49,22 +77,19 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
     });
   }
 
-  function buildIcon(vehicle) {
-    const color = MODE_COLORS[vehicle.mode] || MODE_COLORS.unknown;
-    const icon = MODE_ICONS[vehicle.mode] || MODE_ICONS.unknown;
-    const highlighted = isHighlighted(vehicle.id);
-    if (!highlighted && getZoom() < FULL_MARKER_MIN_ZOOM) {
-      return buildCompactIcon(color);
+  function buildIcon(vehicle, state = visualStateFor(vehicle)) {
+    if (state.compact) {
+      return buildCompactIcon(state.color);
     }
-    const border = highlighted ? '3px solid #ffd400' : '2px solid white';
-    const shadow = highlighted
+    const border = state.highlighted ? '3px solid #ffd400' : '2px solid white';
+    const shadow = state.highlighted
       ? '0 0 0 3px rgba(255,212,0,0.5), 0 2px 4px rgba(0,0,0,0.3)'
       : '0 2px 4px rgba(0,0,0,0.3)';
     return L.divIcon({
-      className: highlighted ? 'vehicle-marker vehicle-marker--highlighted' : 'vehicle-marker',
+      className: state.highlighted ? 'vehicle-marker vehicle-marker--highlighted' : 'vehicle-marker',
       html: `
           <div style="
-            background: ${color};
+            background: ${state.color};
             border: ${border};
             border-radius: 50%;
             width: 20px;
@@ -78,7 +103,7 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
             box-shadow: ${shadow};
             cursor: pointer;
           ">
-            ${vehicle.line?.length <= 3 ? escapeHtml(vehicle.line) : icon}
+            ${vehicle.line?.length <= 3 ? escapeHtml(vehicle.line) : state.icon}
           </div>
         `,
       iconSize: [24, 24],
@@ -97,15 +122,24 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
     },
 
     toPopup(vehicle) {
-      return vehiclePopupContent(vehicle);
+      return lazyPopupContent(vehicle);
+    },
+
+    onMarkerCreated(marker, vehicle) {
+      markerVehicles.set(marker, vehicle);
+      markerVisualStateKeys.set(marker, visualStateFor(vehicle).key);
     },
 
     onUpdate(marker, vehicle) {
+      markerVehicles.set(marker, vehicle);
       marker.setLatLng([vehicle.latitude, vehicle.longitude]);
-      marker.setPopupContent(vehiclePopupContent(vehicle));
-      // Refresh the icon so highlight state tracks the selected Incident.
-      // Guarded: test fakes may not implement setIcon.
-      if (typeof marker.setIcon === 'function') marker.setIcon(buildIcon(vehicle));
+      updateOpenPopup(marker, vehicle);
+
+      const visualState = visualStateFor(vehicle);
+      if (markerVisualStateKeys.get(marker) === visualState.key) return;
+
+      markerVisualStateKeys.set(marker, visualState.key);
+      if (typeof marker.setIcon === 'function') marker.setIcon(buildIcon(vehicle, visualState));
     },
 
     // Moved markers must be re-added for clusters to re-bucket them. Only while

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -1,5 +1,4 @@
-import { describe, it, expect } from 'vitest';
-import { vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createVehicleAdapter, FULL_MARKER_MIN_ZOOM } from './vehicleAdapter';
 
 // Leaflet mock — only the primitives used by vehicleAdapter
@@ -83,5 +82,94 @@ describe('createVehicleAdapter zoom-adaptive icons', () => {
     zoom = FULL_MARKER_MIN_ZOOM - 2;
     adapter.onUpdate(marker, makeVehicle());
     expect(marker.icon.iconSize).toEqual([10, 10]);
+  });
+
+  it('skips icon replacement when the visual state is unchanged', () => {
+    const adapter = createVehicleAdapter({ getZoom: () => FULL_MARKER_MIN_ZOOM });
+    const marker = {
+      setLatLng: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      isPopupOpen: () => false,
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    adapter.onUpdate(marker, makeVehicle({ latitude: 59.34, longitude: 18.08, speed: 14 }));
+
+    expect(marker.setLatLng).toHaveBeenCalledWith([59.34, 18.08]);
+    expect(marker.setIcon).not.toHaveBeenCalled();
+  });
+
+  it('replaces the icon when the visual state changes', () => {
+    let highlighted = false;
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isHighlighted: () => highlighted,
+    });
+    const marker = {
+      setLatLng: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      isPopupOpen: () => false,
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    highlighted = true;
+    adapter.onUpdate(marker, makeVehicle());
+
+    expect(marker.setIcon).toHaveBeenCalledOnce();
+    expect(marker.setIcon.mock.calls[0][0].className).toContain('vehicle-marker--highlighted');
+  });
+});
+
+describe('createVehicleAdapter lazy popups', () => {
+  it('defers vehicle popup formatting until Leaflet resolves popup content', () => {
+    const adapter = createVehicleAdapter();
+    const marker = {};
+    const timeSpy = vi.spyOn(Date.prototype, 'toLocaleTimeString');
+
+    const popupContent = adapter.toPopup(makeVehicle());
+
+    expect(typeof popupContent).toBe('function');
+    expect(timeSpy).not.toHaveBeenCalled();
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    popupContent(marker);
+
+    expect(timeSpy).toHaveBeenCalledOnce();
+    timeSpy.mockRestore();
+  });
+
+  it('renders the latest vehicle state when a lazy popup is opened later', () => {
+    const adapter = createVehicleAdapter();
+    const marker = {
+      setLatLng: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      isPopupOpen: () => false,
+    };
+    const popupContent = adapter.toPopup(makeVehicle({ line: '17' }));
+
+    adapter.onMarkerCreated(marker, makeVehicle({ line: '17' }));
+    adapter.onUpdate(marker, makeVehicle({ line: '18' }));
+
+    expect(popupContent(marker)).toContain('bus 18');
+  });
+
+  it('refreshes popup content only when the popup is open', () => {
+    const adapter = createVehicleAdapter();
+    let open = false;
+    const marker = {
+      setLatLng: vi.fn().mockReturnThis(),
+      setPopupContent: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      isPopupOpen: () => open,
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    adapter.onUpdate(marker, makeVehicle({ speed: 12 }));
+    expect(marker.setPopupContent).not.toHaveBeenCalled();
+
+    open = true;
+    adapter.onUpdate(marker, makeVehicle({ speed: 13 }));
+    expect(marker.setPopupContent).toHaveBeenCalledOnce();
+    expect(typeof marker.setPopupContent.mock.calls[0][0]).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
- Skip vehicle marker `setIcon` / `divIcon` work when the rendered visual state is unchanged (compact/full, color, highlight, label/icon).
- Build vehicle popup content lazily via Leaflet popup content functions, using the latest vehicle state when a popup opens and refreshing content only for already-open popups.
- Part of #127.

Closes #121
Closes #126

## Checks
- `npm test` — 38 test files / 478 tests passed.
- `npm run build` — succeeded; sourcemaps absent in `dist/`.
- Security analysis — diff limited to `vehicleAdapter.js` and tests; popup HTML still flows through escaped `vehiclePopupContent`; no new `innerHTML`/API key/env-file changes; no VITE secret value scan possible because `.env` is absent in this worktree; `npm audit --audit-level=high` reports existing dependency advisories (2 low, 1 moderate, 1 high) with no package changes in this PR.
