### PR TITLE
perf: trim observation buffer incrementally

### DIFF
--- a/src/services/observationBuffer.js
+++ b/src/services/observationBuffer.js
@@ -25,6 +25,37 @@ export class RecordingError extends Error {
   }
 }
 
+function compactExpiredSnapshots(snapshots, cutoff) {
+  let retained = 0;
+  for (const snapshot of snapshots) {
+    if (snapshot.time >= cutoff) {
+      snapshots[retained] = snapshot;
+      retained += 1;
+    }
+  }
+  snapshots.length = retained;
+}
+
+function trimExpiredSnapshots(snapshots, cutoff, isChronological) {
+  if (!isChronological) {
+    compactExpiredSnapshots(snapshots, cutoff);
+    return;
+  }
+
+  let firstRetained = 0;
+  while (firstRetained < snapshots.length && snapshots[firstRetained].time < cutoff) {
+    firstRetained += 1;
+  }
+  if (firstRetained > 0) snapshots.splice(0, firstRetained);
+}
+
+function isChronologicalSnapshots(snapshots) {
+  for (let i = 1; i < snapshots.length; i += 1) {
+    if (snapshots[i].time < snapshots[i - 1].time) return false;
+  }
+  return true;
+}
+
 function isValidSnapshot(s) {
   return (
     s != null &&
@@ -72,6 +103,7 @@ export function parseRecording(input) {
 
 export function createObservationBuffer({ windowMs = DEFAULT_WINDOW_MS } = {}) {
   let snapshots = [];
+  let isChronological = true;
 
   return {
     /**
@@ -84,9 +116,12 @@ export function createObservationBuffer({ windowMs = DEFAULT_WINDOW_MS } = {}) {
      * @returns {number} the number of snapshots retained
      */
     append({ time, vehicles, feeds }) {
+      if (snapshots.length > 0 && time < snapshots[snapshots.length - 1].time) {
+        isChronological = false;
+      }
       snapshots.push({ time, vehicles: vehicles ?? [], feeds: feeds ?? [] });
       const cutoff = time - windowMs;
-      snapshots = snapshots.filter(s => s.time >= cutoff);
+      trimExpiredSnapshots(snapshots, cutoff, isChronological);
       return snapshots.length;
     },
 
@@ -128,6 +163,7 @@ export function createObservationBuffer({ windowMs = DEFAULT_WINDOW_MS } = {}) {
 
     clear() {
       snapshots = [];
+      isChronological = true;
     },
 
     /**
@@ -157,6 +193,7 @@ export function createObservationBuffer({ windowMs = DEFAULT_WINDOW_MS } = {}) {
     importRecording(input) {
       const parsed = parseRecording(input);
       snapshots = parsed.snapshots.map(s => ({ time: s.time, vehicles: s.vehicles }));
+      isChronological = isChronologicalSnapshots(snapshots);
       return snapshots.length;
     },
   };

--- a/src/services/observationBuffer.js
+++ b/src/services/observationBuffer.js
@@ -125,7 +125,11 @@ export function createObservationBuffer({ windowMs = DEFAULT_WINDOW_MS } = {}) {
       return snapshots.length;
     },
 
-    /** Chronological snapshots currently inside the window. */
+    /**
+     * Live snapshots array currently inside the window. Treat as read-only and
+     * do not retain across buffer mutations; append/clear/import may mutate the
+     * same array in place to avoid allocations in the polling hot path.
+     */
     snapshots() {
       return snapshots;
     },

--- a/src/services/observationBuffer.test.js
+++ b/src/services/observationBuffer.test.js
@@ -31,6 +31,19 @@ describe('observationBuffer', () => {
     const times = buf.snapshots().map(s => s.time);
     // cutoff = 6000 - 5000 = 1000; the t=0 snapshot is dropped
     expect(times).toEqual([3000, 6000]);
+
+    buf.append({ time: 8000, vehicles: [v('boundary')] });
+    // cutoff = 8000 - 5000 = 3000; cutoff-boundary snapshots are retained
+    expect(buf.snapshots().map(s => s.time)).toEqual([3000, 6000, 8000]);
+  });
+
+  it('preserves retention semantics when timestamps arrive out of order', () => {
+    const buf = createObservationBuffer({ windowMs: 5000 });
+    buf.append({ time: 10000, vehicles: [v('newer')] });
+    buf.append({ time: 0, vehicles: [v('older')] });
+    buf.append({ time: 11000, vehicles: [v('latest')] });
+
+    expect(buf.snapshots().map(s => s.time)).toEqual([10000, 11000]);
   });
 
   it('defaults vehicles to an empty array', () => {


### PR DESCRIPTION
## Summary
- Replaces per-append `snapshots.filter(...)` rebuilds with incremental prefix trimming for chronological observation snapshots.
- Keeps an in-place compaction fallback for non-chronological timestamps/imports so the previous cutoff retention semantics are preserved.
- Adds coverage for cutoff-boundary retention and out-of-order timestamp behavior.

Closes #120.
Part of #127.

## Performance benefit
Expected medium improvement in the hot append path: normal polling now avoids allocating a rebuilt snapshots array every append and only splices expired head snapshots when the rolling window advances. Non-chronological edge cases still avoid filter allocation via in-place compaction.

## Checks
- `npm test` — passed (38 files, 474 tests)
- `npm run build` — passed; sourcemaps remain disabled (`sourcemap: false`), `dist` contains 0 `.map` files
- Code review agent — no significant issues found after final diff
- Security review agent — no security findings in changed files
- Security diff scan — no new `innerHTML`, popup, API key, `.env`, token, secret, or password paths
- Bundle key check — configured Trafiklab API key value not present in `dist` (no local key configured)
- `npm audit --audit-level=high` — ran; reports existing dependency advisories including 1 high in `undici`; this PR changes no dependencies/package files and introduces no new audit findings
