### PR TITLE
Geolocation: locate-me feature (PRD #111)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Keys from https://developer.trafiklab.se/. Rate limit: Bronze, 50 calls/min — 
 - [docs/adr/0002-dark-mode-tile-provider.md](docs/adr/0002-dark-mode-tile-provider.md) — why CartoDB Dark Matter for dark tiles
 - [docs/adr/0003-client-side-incident-derivation.md](docs/adr/0003-client-side-incident-derivation.md) — why the Command Center derives everything client-side, no backend
 - [docs/adr/0004-webcam-layer-static-images-no-embeds.md](docs/adr/0004-webcam-layer-static-images-no-embeds.md) — webcam embed boundary (hotlinked stills, no third-party embeds)
+- [docs/adr/0005-geolocation-ephemeral-client-only.md](docs/adr/0005-geolocation-ephemeral-client-only.md) — "locate me" position is ephemeral/client-only, never stored or sent
 - [docs/agents/domain.md](docs/agents/domain.md) — how agents consume CONTEXT.md + ADRs
 - [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md) — GitHub issue conventions via `gh`
 - [docs/agents/triage-labels.md](docs/agents/triage-labels.md) — triage label vocabulary

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,12 @@ The current canonical modes are: `metro | bus | train | tram | ferry | unknown`.
 
 `ship` is not a mode: no GTFS `route_type` in the Swedish feeds maps to it. Route type 1000 (Water Transport) maps to `ferry`.
 
+## User location
+
+The map position acquired from the browser's native geolocation, shown as a single "you are here" marker. A User location is **not** a Vehicle: it carries no line, mode, or operator, is styled as a distinct accent (never a transport-mode colour), and never enters the keyed marker-collection — it is one circle marker managed directly in `Map.jsx`. It is a **session-only singleton**: re-locating moves the one marker rather than accumulating, and it is forgotten on reload. Avoid the synonyms "GPS pin" / "current location".
+
+All `navigator.geolocation` interaction lives behind the **`useGeolocation`** hook (`locate()`, `position`, `status`), where `status` is the discriminated enum `idle | locating | success | denied | unavailable` (`denied` = the user declined; `unavailable` = no API / insecure origin — never conflated). The position is **ephemeral and client-only** ([ADR 0005](docs/adr/0005-geolocation-ephemeral-client-only.md)): held in memory only, never written to client storage and never sent to any service, so the browser-native permission prompt is the only gate — no Consent surface and no Privacy Notice change.
+
 ## Filter-selection module
 
 Filter state — enabled modes, selected lines, and the mode/line invariant — is owned entirely by **`src/hooks/useFilterSelection.js`**. No consumer builds or parses selection keys; the hook exposes `{mode, line}` objects and an `isLineSelected(mode, line)` predicate.

--- a/docs/adr/0005-geolocation-ephemeral-client-only.md
+++ b/docs/adr/0005-geolocation-ephemeral-client-only.md
@@ -1,0 +1,42 @@
+# ADR 0005 — Geolocation is ephemeral and client-only
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+
+## Context
+
+The "locate me" feature (PRD #111, first slice #112) acquires the user's position from the browser's native geolocation API to centre the map on where they are. A position is the most identifying data this app handles: it is personal data, and a history of positions would be a record of where the user has physically been.
+
+The app's privacy posture ([ADR 0001](0001-cookieless-no-consent-popup.md)) is cookieless with a Privacy Notice and **no** Consent surface, on the strict condition that the app performs no non-essential storage and no third-party processing of personal data. Persisting the user's location across visits, or sending coordinates to any non-tile service (reverse geocoding, nearest-stop lookup), would be exactly the kind of non-essential processing that reverses ADR 0001 and obliges a real Consent gate.
+
+The browser already provides a native permission prompt for geolocation — a familiar, OS-level, revocable gate that the user trusts.
+
+## Decision
+
+The User location is **ephemeral and client-only**:
+
+- It is held in React state only (the `useGeolocation` hook), for the duration of the session, and forgotten on reload.
+- It is **never** written to client storage (no `localStorage`, no cookie, no IndexedDB).
+- It is **never** sent to any service. The only network effect of locating is that moving the map viewport triggers the operators-in-viewport feed fetch the app already performs — those calls carry the viewport, not the user's coordinates.
+- Permission is governed **solely** by the browser-native prompt. The app adds no custom consent dialog and makes no Privacy Notice change.
+
+## Rationale
+
+- **Keeps ADR 0001 standing.** No non-essential storage and no third-party coordinate sharing are introduced, so the cookieless Privacy-Notice posture survives intact and no Consent surface is required.
+- **Native prompt is the right gate.** Geolocation is the one capability browsers already gate with a trusted, revocable permission; re-implementing consent in-app would be redundant and less trustworthy.
+- **Least data held.** Using the position in the moment and forgetting it means the app cannot build a location history even accidentally.
+
+## Trade-offs
+
+- The user re-grants (or the browser re-confirms) on each fresh visit; there is no "remember my location". This is intentional — story 13 ("no memory of my previous location") is a feature, not a gap.
+- A future "last location" convenience would require persisting a position, which is non-essential storage: it triggers the ADR 0001 reversal and must stand up a Consent surface first.
+
+## Reversal trigger
+
+Persisting the User location across reloads/visits, or sending coordinates to any non-tile service, reverses this decision and ADR 0001 together: the project must then ship the full Consent surface ADR 0001 prescribes, and the location feature lives behind that consent — never before it.
+
+## Related
+
+- [ADR 0001](0001-cookieless-no-consent-popup.md) — cookieless app, Privacy Notice not Consent gate; defines the reversal trigger this ADR avoids.
+- [CONTEXT.md](../../CONTEXT.md) — **User location** glossary term.
+- PRD: `#111` — Geolocation, "locate me" centres the map. First slice: `#112`.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Map } from './components/Map';
 import { CommandCenter } from './components/CommandCenter';
 import { ControlPanel } from './components/ControlPanel';
+import { LocateControl } from './components/LocateControl';
 import { OfflineBanner } from './components/OfflineBanner';
 import { UpdateToast } from './components/UpdateToast';
 import { PrivacyNotice } from './components/PrivacyNotice';
@@ -9,6 +10,7 @@ import { useRealtimeVehicles } from './hooks/useRealtimeVehicles';
 import { useFilterSelection } from './hooks/useFilterSelection';
 import { useTheme } from './hooks/useTheme';
 import { useConnectivity } from './hooks/useConnectivity';
+import { useGeolocation } from './hooks/useGeolocation';
 import { useUpdatePrompt } from './hooks/useUpdatePrompt';
 import { useWebcams } from './hooks/useWebcams';
 import {
@@ -21,6 +23,7 @@ import { OPERATORS, OPERATOR_MAP, SWEDEN_CENTER, SWEDEN_ZOOM, getVisibleOperator
 function App() {
   const { theme, toggleTheme } = useTheme();
   const { isOnline } = useConnectivity();
+  const { locate, position: userLocation, status: geolocationStatus } = useGeolocation();
   const { needRefresh, updateServiceWorker, dismissUpdate } = useUpdatePrompt();
   const [mapCenter, setMapCenter] = useState([59.3293, 18.0686]);
   const [mapZoom, setMapZoom] = useState(11);
@@ -30,6 +33,17 @@ function App() {
   const [enabledCameraTypes, setEnabledCameraTypes] = useState(
     CAMERA_TYPE_DEFINITIONS.map(t => t.id),
   );
+
+  // Fly to the User location when a fix arrives, at city-level zoom (~12).
+  // This reuses the existing center/zoom → Map flyTo seam; moving the viewport
+  // also triggers the viewport→operators fetch, so the user's region loads
+  // its vehicles with no geolocation-specific polling code (PRD #111).
+  useEffect(() => {
+    if (userLocation) {
+      setMapCenter([userLocation.latitude, userLocation.longitude]);
+      setMapZoom(12);
+    }
+  }, [userLocation]);
 
   const { cameras, error: webcamsError, errors: webcamsErrors, loading: webcamsLoading } = useWebcams(webcamsEnabled);
 
@@ -121,6 +135,7 @@ function App() {
         zoom={mapZoom}
         onBoundsChange={handleBoundsChange}
         theme={theme}
+        userLocation={userLocation}
       />
       <ControlPanel
         vehicles={filteredVehicles}
@@ -155,6 +170,7 @@ function App() {
         cameraCounts={cameraCounts}
         onCameraTypeToggle={handleCameraTypeToggle}
       />
+      <LocateControl status={geolocationStatus} onLocate={locate} />
       <OfflineBanner isOnline={isOnline} />
       <UpdateToast isVisible={needRefresh} onReload={updateServiceWorker} onDismiss={dismissUpdate} />
       <PrivacyNotice />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -170,7 +170,7 @@ function App() {
         cameraCounts={cameraCounts}
         onCameraTypeToggle={handleCameraTypeToggle}
       />
-      <LocateControl status={geolocationStatus} onLocate={locate} />
+      <LocateControl status={geolocationStatus} onLocate={locate} theme={theme} />
       <OfflineBanner isOnline={isOnline} />
       <UpdateToast isVisible={needRefresh} onReload={updateServiceWorker} onDismiss={dismissUpdate} />
       <PrivacyNotice />

--- a/src/components/LocateControl.css
+++ b/src/components/LocateControl.css
@@ -1,0 +1,38 @@
+.locate-control {
+  position: absolute;
+  bottom: 24px;
+  right: 12px;
+  z-index: 1000;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  color: #1d6fe0;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
+}
+
+.locate-control:hover {
+  background: #f4f4f4;
+}
+
+.locate-control:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+[data-theme="dark"] .locate-control {
+  background: #1e1e2e;
+  color: #5b9dff;
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+[data-theme="dark"] .locate-control:hover {
+  background: #2a2a3e;
+}

--- a/src/components/LocateControl.css
+++ b/src/components/LocateControl.css
@@ -46,12 +46,15 @@
   }
 }
 
-[data-theme="dark"] .locate-control {
+/* Theme-aware styling (issue #115, story 15): keyed off the control's own
+   data-theme attribute (set from the active theme) rather than an ancestor, so
+   the button stays legible on dark tiles and the styling is self-contained. */
+.locate-control[data-theme="dark"] {
   background: #1e1e2e;
   color: #5b9dff;
   border-color: rgba(255, 255, 255, 0.25);
 }
 
-[data-theme="dark"] .locate-control:hover {
+.locate-control[data-theme="dark"]:hover {
   background: #2a2a3e;
 }

--- a/src/components/LocateControl.css
+++ b/src/components/LocateControl.css
@@ -27,6 +27,25 @@
   opacity: 0.6;
 }
 
+/* In-progress feedback while a fix is being acquired (issue #114, PRD #111
+   story 9): the busy glyph spins so the tap reads as registered and working.
+   Cleared automatically once status leaves locating — the modifier class is a
+   pure function of status === 'locating'. */
+.locate-control--busy {
+  animation: locate-control-spin 0.9s linear infinite;
+}
+
+@keyframes locate-control-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .locate-control--busy {
+    animation: none;
+  }
+}
+
 [data-theme="dark"] .locate-control {
   background: #1e1e2e;
   color: #5b9dff;

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -4,21 +4,34 @@ import './LocateControl.css';
 // zoom + view toggle). A thin presenter: it derives everything from the
 // useGeolocation status and holds no geolocation logic of its own.
 //
-// This slice (issue #112) covers idle → locating → success. The button shows a
-// pending state while locating and is otherwise tappable. denied/unavailable
-// tooltips and disabling land in a later slice.
+// Enabled state and tooltip are a pure mapping from status (issue #113). The two
+// non-success terminal states are kept distinct: denied (the user refused) and
+// unavailable (no capability — insecure origin / no API) get separate tooltips
+// so refusal is never conflated with absent capability.
+const TOOLTIP = {
+  idle: 'Locate me',
+  locating: 'Locate me',
+  success: 'Locate me',
+  denied: 'you declined location access',
+  unavailable: 'location is unavailable in this context',
+};
+
+const DISABLED = new Set(['locating', 'denied', 'unavailable']);
+
 export function LocateControl({ status = 'idle', onLocate }) {
   const locating = status === 'locating';
+  const disabled = DISABLED.has(status);
+  const title = TOOLTIP[status] ?? TOOLTIP.idle;
 
   return (
     <button
       type="button"
       className="locate-control"
       onClick={onLocate}
-      disabled={locating}
+      disabled={disabled}
       aria-label="Locate me"
       aria-busy={locating}
-      title="Locate me"
+      title={title}
     >
       {locating ? '…' : '◎'}
     </button>

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -8,6 +8,11 @@ import './LocateControl.css';
 // non-success terminal states are kept distinct: denied (the user refused) and
 // unavailable (no capability — insecure origin / no API) get separate tooltips
 // so refusal is never conflated with absent capability.
+//
+// In-progress feedback (issue #114, story 9): while status === 'locating' the
+// button is aria-busy and carries the --busy modifier (a spinning glyph), so a
+// tap visibly registers. It clears the moment status leaves locating — success,
+// denied, timeout, or unavailable all return the button to its resting state.
 const TOOLTIP = {
   idle: 'Locate me',
   locating: 'Locate me',
@@ -26,7 +31,7 @@ export function LocateControl({ status = 'idle', onLocate }) {
   return (
     <button
       type="button"
-      className="locate-control"
+      className={locating ? 'locate-control locate-control--busy' : 'locate-control'}
       onClick={onLocate}
       disabled={disabled}
       aria-label="Locate me"

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -1,0 +1,26 @@
+import './LocateControl.css';
+
+// "Locate me" map control, bottom-right (top-left = ControlPanel, top-right =
+// zoom + view toggle). A thin presenter: it derives everything from the
+// useGeolocation status and holds no geolocation logic of its own.
+//
+// This slice (issue #112) covers idle → locating → success. The button shows a
+// pending state while locating and is otherwise tappable. denied/unavailable
+// tooltips and disabling land in a later slice.
+export function LocateControl({ status = 'idle', onLocate }) {
+  const locating = status === 'locating';
+
+  return (
+    <button
+      type="button"
+      className="locate-control"
+      onClick={onLocate}
+      disabled={locating}
+      aria-label="Locate me"
+      aria-busy={locating}
+      title="Locate me"
+    >
+      {locating ? '…' : '◎'}
+    </button>
+  );
+}

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -13,6 +13,11 @@ import './LocateControl.css';
 // button is aria-busy and carries the --busy modifier (a spinning glyph), so a
 // tap visibly registers. It clears the moment status leaves locating — success,
 // denied, timeout, or unavailable all return the button to its resting state.
+//
+// Theme-awareness (issue #115, story 15): the active theme is reflected as a
+// data-theme attribute on the button so its dark/light styling is self-contained
+// (CSS keys off .locate-control[data-theme="dark"]) and assertable at the RTL
+// level — no reliance on an ancestor [data-theme] for this control.
 const TOOLTIP = {
   idle: 'Locate me',
   locating: 'Locate me',
@@ -23,7 +28,7 @@ const TOOLTIP = {
 
 const DISABLED = new Set(['locating', 'denied', 'unavailable']);
 
-export function LocateControl({ status = 'idle', onLocate }) {
+export function LocateControl({ status = 'idle', onLocate, theme = 'light' }) {
   const locating = status === 'locating';
   const disabled = DISABLED.has(status);
   const title = TOOLTIP[status] ?? TOOLTIP.idle;
@@ -36,6 +41,7 @@ export function LocateControl({ status = 'idle', onLocate }) {
       disabled={disabled}
       aria-label="Locate me"
       aria-busy={locating}
+      data-theme={theme}
       title={title}
     >
       {locating ? '…' : '◎'}

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -49,4 +49,29 @@ describe('LocateControl', () => {
     const unavailableTitle = screen.getByRole('button', { name: /locat/i }).title;
     expect(deniedTitle).not.toBe(unavailableTitle);
   });
+
+  // Issue #114 / PRD #111 story 9 — in-progress feedback while acquiring the fix.
+  it('shows an in-progress busy indicator while locating', () => {
+    render(<LocateControl status="locating" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.getAttribute('aria-busy')).toBe('true');
+    expect(btn.className).toContain('locate-control--busy');
+  });
+
+  it('clears the in-progress indicator once a fix arrives', () => {
+    render(<LocateControl status="success" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.getAttribute('aria-busy')).toBe('false');
+    expect(btn.className).not.toContain('locate-control--busy');
+  });
+
+  it('clears the in-progress indicator if the request is denied or unavailable', () => {
+    for (const status of ['denied', 'unavailable', 'idle']) {
+      const { unmount } = render(<LocateControl status={status} onLocate={() => {}} />);
+      const btn = screen.getByRole('button', { name: /locat/i });
+      expect(btn.getAttribute('aria-busy')).toBe('false');
+      expect(btn.className).not.toContain('locate-control--busy');
+      unmount();
+    }
+  });
 });

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -74,4 +74,24 @@ describe('LocateControl', () => {
       unmount();
     }
   });
+
+  // Issue #115 / PRD #111 story 14 — keyboard / screen-reader accessibility.
+  it('is keyboard-focusable and exposes an accessible name describing "locate me"', () => {
+    render(<LocateControl status="idle" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locate me/i });
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+    // a native <button> activates on Enter/Space — keyboard activation routes to onClick.
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.disabled).toBe(false);
+  });
+
+  // Issue #115 / PRD #111 story 15 — button is theme-aware (legible per theme).
+  it('reflects the active theme so it can be styled legibly per theme', () => {
+    const { unmount } = render(<LocateControl status="idle" theme="dark" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locat/i }).getAttribute('data-theme')).toBe('dark');
+    unmount();
+    render(<LocateControl status="idle" theme="light" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locat/i }).getAttribute('data-theme')).toBe('light');
+  });
 });

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -26,4 +26,27 @@ describe('LocateControl', () => {
     render(<LocateControl status="success" onLocate={() => {}} />);
     expect(screen.getByRole('button', { name: /locate/i }).disabled).toBe(false);
   });
+
+  it('disables the button and explains the decline when permission is denied', () => {
+    render(<LocateControl status="denied" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toBe('you declined location access');
+  });
+
+  it('disables the button with a distinct tooltip when geolocation is unavailable', () => {
+    render(<LocateControl status="unavailable" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toBe('location is unavailable in this context');
+  });
+
+  it('uses distinct tooltips for denied versus unavailable (never conflated)', () => {
+    const { unmount } = render(<LocateControl status="denied" onLocate={() => {}} />);
+    const deniedTitle = screen.getByRole('button', { name: /locat/i }).title;
+    unmount();
+    render(<LocateControl status="unavailable" onLocate={() => {}} />);
+    const unavailableTitle = screen.getByRole('button', { name: /locat/i }).title;
+    expect(deniedTitle).not.toBe(unavailableTitle);
+  });
 });

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LocateControl } from './LocateControl';
+
+describe('LocateControl', () => {
+  it('renders a labelled, focusable button', () => {
+    render(<LocateControl status="idle" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locate/i });
+    expect(btn).toBeTruthy();
+    expect(btn.tagName).toBe('BUTTON');
+  });
+
+  it('calls onLocate when tapped', () => {
+    const onLocate = vi.fn();
+    render(<LocateControl status="idle" onLocate={onLocate} />);
+    fireEvent.click(screen.getByRole('button', { name: /locate/i }));
+    expect(onLocate).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button while a fix is being acquired', () => {
+    render(<LocateControl status="locating" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locat/i }).disabled).toBe(true);
+  });
+
+  it('is enabled again after a successful fix', () => {
+    render(<LocateControl status="success" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locate/i }).disabled).toBe(false);
+  });
+});

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -9,9 +9,13 @@ import { createMarkerCollection } from '../services/markerCollection';
 import { createVehicleAdapter, FULL_MARKER_MIN_ZOOM } from '../services/vehicleAdapter';
 import { createWebcamAdapter } from '../services/webcamAdapter';
 
-export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = [] }) {
+export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = [], userLocation = null }) {
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
+  // Singleton User location marker (PRD #111). A single circle marker managed
+  // directly here — deliberately NOT routed through the keyed marker-collection,
+  // which exists for id-diffed collections. Re-locating moves this one marker.
+  const userMarkerRef = useRef(null);
   const vehicleCollectionRef = useRef(null);
   // Highlight set is read live by the adapter so selection changes are reflected.
   const highlightRef = useRef(new Set());
@@ -138,6 +142,27 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   useEffect(() => {
     webcamCollectionRef.current?.update(cameras, webcamAdapterRef.current);
   }, [cameras]);
+
+  // User location singleton: place once, then move on subsequent fixes. Styled
+  // as a distinct "you are here" blue accent — never a transport-mode colour —
+  // so it is never mistaken for a Vehicle.
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map || !userLocation) return;
+    const latlng = [userLocation.latitude, userLocation.longitude];
+    if (userMarkerRef.current) {
+      userMarkerRef.current.setLatLng(latlng);
+    } else {
+      userMarkerRef.current = L.circleMarker(latlng, {
+        radius: 8,
+        color: '#ffffff',
+        weight: 2,
+        fillColor: '#1d6fe0',
+        fillOpacity: 1,
+      }).addTo(map);
+      userMarkerRef.current.bindTooltip('You are here');
+    }
+  }, [userLocation]);
 
   return (
     <div

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -145,24 +145,29 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
 
   // User location singleton: place once, then move on subsequent fixes. Styled
   // as a distinct "you are here" blue accent — never a transport-mode colour —
-  // so it is never mistaken for a Vehicle.
+  // so it is never mistaken for a Vehicle. The accent is theme-aware (issue
+  // #115, story 15): a deeper blue on light tiles, a brighter blue on dark tiles
+  // (matching the locate button), so it stays legible against either basemap
+  // while keeping its distinct white-ringed accent. Restyled on theme change.
   useEffect(() => {
     const map = mapInstanceRef.current;
     if (!map || !userLocation) return;
     const latlng = [userLocation.latitude, userLocation.longitude];
+    const style = {
+      radius: 8,
+      color: '#ffffff',
+      weight: 2,
+      fillColor: theme === 'dark' ? '#5b9dff' : '#1d6fe0',
+      fillOpacity: 1,
+    };
     if (userMarkerRef.current) {
       userMarkerRef.current.setLatLng(latlng);
+      userMarkerRef.current.setStyle(style);
     } else {
-      userMarkerRef.current = L.circleMarker(latlng, {
-        radius: 8,
-        color: '#ffffff',
-        weight: 2,
-        fillColor: '#1d6fe0',
-        fillOpacity: 1,
-      }).addTo(map);
+      userMarkerRef.current = L.circleMarker(latlng, style).addTo(map);
       userMarkerRef.current.bindTooltip('You are here');
     }
-  }, [userLocation]);
+  }, [userLocation, theme]);
 
   return (
     <div

--- a/src/hooks/useGeolocation.js
+++ b/src/hooks/useGeolocation.js
@@ -1,0 +1,43 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+// All navigator.geolocation interaction lives behind this hook (the project's
+// "I/O behind a hook" rule). The position is ephemeral and client-only
+// (ADR 0005): held in React state only, never persisted, never sent anywhere.
+//
+// status is a discriminated enum: idle | locating | success | denied | unavailable.
+// This slice (issue #112) establishes idle → locating → success; denied/unavailable
+// are produced by the error path but their button UI lands in a later slice.
+
+// Standard accuracy (not GPS-grade) for a fast city-level fix; ~10s timeout;
+// a modest cache so a recent fix can return immediately.
+const GEO_OPTIONS = { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 };
+
+export function useGeolocation() {
+  const [status, setStatus] = useState('idle');
+  const [position, setPosition] = useState(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => () => { mountedRef.current = false; }, []);
+
+  const locate = useCallback(() => {
+    if (!navigator.geolocation) {
+      setStatus('unavailable');
+      return;
+    }
+    setStatus('locating');
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (!mountedRef.current) return;
+        setPosition({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+        setStatus('success');
+      },
+      (err) => {
+        if (!mountedRef.current) return;
+        setStatus(err && err.code === err.PERMISSION_DENIED ? 'denied' : 'unavailable');
+      },
+      GEO_OPTIONS,
+    );
+  }, []);
+
+  return { locate, position, status };
+}

--- a/src/hooks/useGeolocation.js
+++ b/src/hooks/useGeolocation.js
@@ -5,22 +5,31 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 // (ADR 0005): held in React state only, never persisted, never sent anywhere.
 //
 // status is a discriminated enum: idle | locating | success | denied | unavailable.
-// This slice (issue #112) establishes idle → locating → success; denied/unavailable
-// are produced by the error path but their button UI lands in a later slice.
+// Capability is evaluated up front (issue #113): if navigator.geolocation is
+// missing/blocked (insecure origin, no API support) the hook starts in
+// unavailable so the button is disabled before any tap. denied is the distinct
+// terminal state for a refused permission — refusal and absent capability are
+// never conflated (cf. the source-absence-vs-failure discipline).
+
+// Geolocation capability — absent API or insecure origin means the feature can
+// never produce a fix, distinct from a fix that was refused.
+function geolocationAvailable() {
+  return typeof navigator !== 'undefined' && !!navigator.geolocation;
+}
 
 // Standard accuracy (not GPS-grade) for a fast city-level fix; ~10s timeout;
 // a modest cache so a recent fix can return immediately.
 const GEO_OPTIONS = { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 };
 
 export function useGeolocation() {
-  const [status, setStatus] = useState('idle');
+  const [status, setStatus] = useState(() => (geolocationAvailable() ? 'idle' : 'unavailable'));
   const [position, setPosition] = useState(null);
   const mountedRef = useRef(true);
 
   useEffect(() => () => { mountedRef.current = false; }, []);
 
   const locate = useCallback(() => {
-    if (!navigator.geolocation) {
+    if (!geolocationAvailable()) {
       setStatus('unavailable');
       return;
     }

--- a/src/hooks/useGeolocation.test.js
+++ b/src/hooks/useGeolocation.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useGeolocation } from './useGeolocation';
+
+// Capture the success/error callbacks getCurrentPosition is invoked with so
+// tests can drive the async resolution deterministically (cf. useConnectivity).
+function installGeolocation() {
+  const calls = [];
+  const getCurrentPosition = vi.fn((onSuccess, onError, options) => {
+    calls.push({ onSuccess, onError, options });
+  });
+  navigator.geolocation = { getCurrentPosition };
+  return { calls, getCurrentPosition };
+}
+
+const malmoFix = {
+  coords: { latitude: 55.6050, longitude: 13.0038 },
+};
+
+describe('useGeolocation', () => {
+  let original;
+
+  beforeEach(() => {
+    original = navigator.geolocation;
+  });
+
+  afterEach(() => {
+    navigator.geolocation = original;
+    vi.restoreAllMocks();
+  });
+
+  it('starts idle with no position', () => {
+    installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    expect(result.current.status).toBe('idle');
+    expect(result.current.position).toBeNull();
+  });
+
+  it('reports locating while a fix is pending', () => {
+    installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    expect(result.current.status).toBe('locating');
+    expect(result.current.position).toBeNull();
+  });
+
+  it('yields success and the position when a fix arrives', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    act(() => { calls[0].onSuccess(malmoFix); });
+    expect(result.current.status).toBe('success');
+    expect(result.current.position).toEqual({ latitude: 55.6050, longitude: 13.0038 });
+  });
+
+  it('does not update state after unmount', () => {
+    const { calls } = installGeolocation();
+    const { result, unmount } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    unmount();
+    act(() => { calls[0].onSuccess(malmoFix); });
+    expect(result.current.status).toBe('locating');
+    expect(result.current.position).toBeNull();
+  });
+
+  it('requests a standard-accuracy fix with a ~10s timeout', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    expect(calls[0].options).toMatchObject({ enableHighAccuracy: false, timeout: 10000 });
+    expect(calls[0].options.maximumAge).toBeGreaterThan(0);
+  });
+
+  it('exposes exactly { locate, position, status }', () => {
+    installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    expect(Object.keys(result.current).sort()).toEqual(['locate', 'position', 'status']);
+    expect(typeof result.current.locate).toBe('function');
+  });
+});

--- a/src/hooks/useGeolocation.test.js
+++ b/src/hooks/useGeolocation.test.js
@@ -71,6 +71,28 @@ describe('useGeolocation', () => {
     expect(calls[0].options.maximumAge).toBeGreaterThan(0);
   });
 
+  it('evaluates capability on mount: a missing geolocation API yields unavailable', () => {
+    navigator.geolocation = undefined;
+    const { result } = renderHook(() => useGeolocation());
+    expect(result.current.status).toBe('unavailable');
+  });
+
+  it('resolves to denied when the user rejects the permission', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    act(() => { calls[0].onError({ code: 1, PERMISSION_DENIED: 1 }); });
+    expect(result.current.status).toBe('denied');
+  });
+
+  it('resolves to unavailable when the position is otherwise unobtainable', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    act(() => { calls[0].onError({ code: 2, PERMISSION_DENIED: 1 }); });
+    expect(result.current.status).toBe('unavailable');
+  });
+
   it('exposes exactly { locate, position, status }', () => {
     installGeolocation();
     const { result } = renderHook(() => useGeolocation());


### PR DESCRIPTION
Integrates the completed **geolocation locate-me** feature into `develop`.

PRD #111; closed slices #112 (fly-to + singleton marker), #113 (denied/unavailable states), #114 (in-progress feedback), #115 (accessibility + theme). The sandcastle branches were a linear stack — this is the tip, so all slices are included.

**New:** `useGeolocation` hook, `LocateControl`, ADR 0006 (geolocation ephemeral/client-only).

**Conflict resolutions:**
- `AGENTS.md` — kept develop's progressive-disclosure refactor; added ADR 0006 to the index.
- `Map.jsx` — kept develop's marker-perf helpers + added the `userLocation` prop and User location marker.
- ADR renumbered `0005`→`0006` (0005 was already the projections ADR); refs updated in `CONTEXT.md` + `useGeolocation.js`.

**Gates:** 529 tests pass (41 files; +21 from the geolocation tests), build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)