### PR TITLE
Palantir control-panel prototype (dev-only UI variants)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,9 @@ import { useState, useMemo, useEffect } from 'react';
 import { Map } from './components/Map';
 import { CommandCenter } from './components/CommandCenter';
 import { ControlPanel } from './components/ControlPanel';
+// PROTOTYPE — fancy-interface variants, dev-only. Remove with src/components/prototype/. See NOTES.md.
+import { FancyControlPanel } from './components/prototype/FancyControlPanel';
+const PanelComponent = import.meta.env.DEV ? FancyControlPanel : ControlPanel;
 import { LocateControl } from './components/LocateControl';
 import { OfflineBanner } from './components/OfflineBanner';
 import { UpdateToast } from './components/UpdateToast';
@@ -137,7 +140,7 @@ function App() {
         theme={theme}
         userLocation={userLocation}
       />
-      <ControlPanel
+      <PanelComponent
         vehicles={filteredVehicles}
         loading={loading}
         error={error}

--- a/src/components/prototype/FancyControlPanel.jsx
+++ b/src/components/prototype/FancyControlPanel.jsx
@@ -1,0 +1,40 @@
+// PROTOTYPE — throwaway. Drop-in replacement for <ControlPanel> in dev that
+// renders one of several "fancy" variants, chosen by the ?variant= URL param,
+// with a floating switcher bar to flip between them. Hidden in production.
+//
+// Question being answered: "what should a fancier interface look like?"
+// Sub-shape A — same map route, only the panel rendering swaps. See NOTES.md.
+import { useEffect, useState } from 'react';
+import { ControlPanel } from '../ControlPanel';
+import { VariantGlassHud } from './VariantGlassHud';
+import { VariantCommandDock } from './VariantCommandDock';
+import { VariantIconRail } from './VariantIconRail';
+import { PrototypeSwitcher } from './PrototypeSwitcher';
+
+function useVariantParam() {
+  const read = () => new URLSearchParams(window.location.search).get('variant') || 'C';
+  const [variant, setVariant] = useState(read);
+  useEffect(() => {
+    const onChange = () => setVariant(read());
+    window.addEventListener('popstate', onChange);
+    return () => window.removeEventListener('popstate', onChange);
+  }, []);
+  return variant;
+}
+
+export function FancyControlPanel(props) {
+  const variant = useVariantParam();
+
+  let panel;
+  if (variant === 'B') panel = <VariantCommandDock {...props} />;
+  else if (variant === 'C') panel = <VariantIconRail {...props} />;
+  else if (variant === 'original') panel = <ControlPanel {...props} />;
+  else panel = <VariantGlassHud {...props} />;
+
+  return (
+    <>
+      {panel}
+      <PrototypeSwitcher current={variant} />
+    </>
+  );
+}

--- a/src/components/prototype/NOTES.md
+++ b/src/components/prototype/NOTES.md
@@ -1,0 +1,47 @@
+# PROTOTYPE — Fancier control panel
+
+**Question:** What should a fancier version of the map control panel look like?
+
+**Shape:** UI prototype, sub-shape A — same map route, only the panel rendering
+swaps via a `?variant=` URL param. Dev-only; production keeps the real
+`ControlPanel` (`App.jsx` gates on `import.meta.env.DEV`).
+
+## How to run
+
+```bash
+npm run dev   # http://localhost:3000
+```
+
+Flip variants with the floating pill at the bottom-centre, the ← / → keys, or by
+setting `?variant=A|B|C|original` in the URL. Toggle dark mode (🌙) — every
+variant is theme-aware via the existing `--chrome-*` CSS vars.
+
+## Variants (structurally different, not recolours)
+
+- **A — Glass HUD** (`VariantGlassHud`): frosted translucent left panel, hero
+  stat numbers, glowing segmented mode pills. Vertical, premium reskin.
+- **B — Command Dock** (`VariantCommandDock`): horizontal bar pinned to the
+  bottom. Stats inline left, segmented mode control as the hero, regions/lines
+  behind popovers that open upward.
+- **C — Icon Rail** (`VariantIconRail`): thin vertical icon rail; each icon
+  opens a contextual flyout. Hierarchy collapsed to icons; Overview flyout has
+  a mode-distribution bar chart.
+- **original**: the current `ControlPanel`, for side-by-side comparison.
+
+## Verdict
+
+**Winner: C — Icon Rail.** Per picked the rail + contextual-flyout structure and
+asked for a **Palantir-inspired** aesthetic. Variant C has been reskinned to a
+command-console look: hairline borders, sharp 2px corners, a steel-blue accent,
+monospace readouts, uppercase micro-labels, and a LIVE/SYNC status strip. It is
+now the default variant (`?variant=C`). Dark mode carries the signature
+near-black slate palette; light mode is a neutral usable fallback.
+
+Still open before production fold-in: re-add the **favourites stars** and
+**camera-type sub-filters** the prototype dropped, write tests, and replace the
+real `ControlPanel`. This PR ships the prototype for design sign-off only.
+
+## Files (all throwaway)
+
+- `src/components/prototype/` — variants, switcher, shared helpers, this file
+- `App.jsx` — the `PanelComponent` dev gate (3 added lines)

--- a/src/components/prototype/PrototypeSwitcher.css
+++ b/src/components/prototype/PrototypeSwitcher.css
@@ -1,0 +1,43 @@
+/* PROTOTYPE — throwaway. High-contrast pill so it's obviously not the design. */
+.proto-switcher {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  border-radius: 999px;
+  background: #111;
+  color: #fff;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+  font: 600 13px/1 -apple-system, system-ui, sans-serif;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.proto-switcher-label {
+  padding: 0 10px;
+  white-space: nowrap;
+}
+
+.proto-switcher-label strong {
+  color: #4ECDC4;
+}
+
+.proto-switcher-arrow {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.proto-switcher-arrow:hover {
+  background: rgba(255, 255, 255, 0.25);
+}

--- a/src/components/prototype/PrototypeSwitcher.jsx
+++ b/src/components/prototype/PrototypeSwitcher.jsx
@@ -1,0 +1,59 @@
+// PROTOTYPE — throwaway floating switcher. Hidden in production builds.
+import { useEffect } from 'react';
+import './PrototypeSwitcher.css';
+
+// Keep in sync with FancyControlPanel's variant map.
+const VARIANTS = [
+  { key: 'A', name: 'Glass HUD' },
+  { key: 'B', name: 'Command Dock' },
+  { key: 'C', name: 'Icon Rail · Palantir' },
+  { key: 'original', name: 'Original (current)' },
+];
+
+function setVariant(key) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('variant', key);
+  window.history.replaceState({}, '', url);
+  // No router in this SPA — nudge React via a popstate so the param re-reads.
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function PrototypeSwitcher({ current }) {
+  const idx = Math.max(0, VARIANTS.findIndex(v => v.key === current));
+  const cur = VARIANTS[idx];
+
+  useEffect(() => {
+    const onKey = (e) => {
+      const t = e.target;
+      const typing =
+        t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+      if (typing) return;
+      if (e.key === 'ArrowLeft') setVariant(VARIANTS[(idx - 1 + VARIANTS.length) % VARIANTS.length].key);
+      if (e.key === 'ArrowRight') setVariant(VARIANTS[(idx + 1) % VARIANTS.length].key);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [idx]);
+
+  return (
+    <div className="proto-switcher" role="group" aria-label="Prototype variant switcher">
+      <button
+        className="proto-switcher-arrow"
+        onClick={() => setVariant(VARIANTS[(idx - 1 + VARIANTS.length) % VARIANTS.length].key)}
+        aria-label="Previous variant"
+      >
+        ‹
+      </button>
+      <span className="proto-switcher-label">
+        <strong>{cur.key}</strong> — {cur.name}
+      </span>
+      <button
+        className="proto-switcher-arrow"
+        onClick={() => setVariant(VARIANTS[(idx + 1) % VARIANTS.length].key)}
+        aria-label="Next variant"
+      >
+        ›
+      </button>
+    </div>
+  );
+}

--- a/src/components/prototype/VariantCommandDock.css
+++ b/src/components/prototype/VariantCommandDock.css
@@ -1,0 +1,87 @@
+/* PROTOTYPE — Variant B "Command Dock". Bottom horizontal command bar. */
+.dock-root {
+  position: absolute;
+  left: 50%;
+  bottom: 70px; /* clears the prototype switcher pill */
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  max-width: calc(100vw - 40px);
+  font-family: -apple-system, system-ui, sans-serif;
+}
+
+.dock {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--chrome-bg) 85%, transparent);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--chrome-border);
+  box-shadow: 0 10px 36px var(--chrome-shadow);
+  color: var(--chrome-text);
+}
+
+.dock-stats { display: flex; gap: 14px; }
+.dock-stat { display: flex; flex-direction: column; align-items: center; line-height: 1.1; }
+.dock-stat b { font-size: 20px; font-weight: 800; letter-spacing: -.5px; }
+.dock-stat span { font-size: 10px; color: var(--chrome-text-muted); text-transform: uppercase; letter-spacing: .5px; }
+
+.dock-divider { width: 1px; align-self: stretch; background: var(--chrome-border); }
+
+.dock-segment {
+  display: flex; gap: 0; border-radius: 10px; overflow: hidden;
+  border: 1px solid var(--chrome-border);
+}
+.dock-seg {
+  display: flex; align-items: center; gap: 5px;
+  padding: 7px 11px; border: none; border-right: 1px solid var(--chrome-border);
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  font-size: 12px; font-weight: 600; cursor: pointer; transition: all .15s;
+}
+.dock-seg:last-child { border-right: none; }
+.dock-seg:not(.on) { opacity: .5; }
+.dock-seg-count { font-size: 10px; opacity: .85; }
+
+.dock-actions { display: flex; align-items: center; gap: 6px; }
+.dock-btn {
+  position: relative;
+  padding: 7px 11px; border-radius: 10px; border: 1px solid var(--chrome-border);
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  font-size: 12px; font-weight: 600; cursor: pointer; white-space: nowrap;
+}
+.dock-btn.icon { padding: 7px 9px; font-size: 14px; }
+.dock-btn.open { border-color: #4ECDC4; background: var(--chrome-chip-selected-bg); }
+.dock-btn:disabled { opacity: .6; }
+.dock-badge {
+  margin-left: 5px; background: #4ECDC4; color: #fff; border-radius: 9px;
+  font-size: 10px; padding: 1px 6px;
+}
+
+.dock-pop {
+  width: min(520px, calc(100vw - 40px));
+  padding: 14px 16px; border-radius: 14px;
+  background: var(--chrome-bg); border: 1px solid var(--chrome-border);
+  box-shadow: 0 10px 36px var(--chrome-shadow); color: var(--chrome-text);
+}
+.dock-pop-title { font-size: 12px; font-weight: 700; color: var(--chrome-text-strong); margin-bottom: 10px; text-transform: uppercase; letter-spacing: .5px; }
+.dock-pop-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.dock-pop-chips.scroll { max-height: 160px; overflow-y: auto; }
+.dock-search {
+  width: 100%; box-sizing: border-box; padding: 8px 11px; margin-bottom: 10px;
+  border-radius: 9px; border: 1px solid var(--chrome-border);
+  background: var(--chrome-chip-bg); color: var(--chrome-text); font-size: 13px; outline: none;
+}
+.dock-search:focus { border-color: #4ECDC4; }
+.dock-chip {
+  padding: 4px 11px; border-radius: 999px; font-size: 12px; font-weight: 600; cursor: pointer;
+  background: var(--chrome-chip-bg); border: 1.5px solid var(--chrome-border); color: var(--chrome-text);
+}
+.dock-chip.all { border-color: #4ECDC4; color: #45b8af; }
+.dock-chip.active { border-color: var(--accent, #4ECDC4); background: var(--chrome-chip-selected-bg); }
+.dock-empty { color: var(--chrome-text-muted); font-size: 12px; }

--- a/src/components/prototype/VariantCommandDock.jsx
+++ b/src/components/prototype/VariantCommandDock.jsx
@@ -1,0 +1,106 @@
+// PROTOTYPE — Variant B "Command Dock". Horizontal bar pinned to the bottom.
+// Different hierarchy: stats inline left, segmented mode control as the hero,
+// regions/lines/layers behind popovers that open *upward* from the dock.
+import { useState } from 'react';
+import './VariantCommandDock.css';
+import { MODES, MODE_COLORS } from '../../services/modes';
+import { countByMode, filterLines } from './prototypeShared';
+
+export function VariantCommandDock(props) {
+  const {
+    vehicles = [], loading, onRefresh,
+    enabledModes = [], onModeToggle,
+    availableLines = {}, isLineSelected = () => false, onLineToggle = () => {},
+    selectedLines = [],
+    operators = [], activeOperators = [], onRegionSelect = () => {},
+    theme, onToggleTheme,
+    webcamsEnabled, onWebcamsToggle, webcamCount = 0,
+  } = props;
+
+  const [open, setOpen] = useState(null); // 'regions' | 'lines' | null
+  const [search, setSearch] = useState('');
+  const stats = countByMode(vehicles);
+  const lineOptions = filterLines(availableLines, search);
+  const toggle = (p) => setOpen(o => (o === p ? null : p));
+
+  return (
+    <div className="dock-root">
+      {open === 'regions' && (
+        <div className="dock-pop">
+          <div className="dock-pop-title">Regions</div>
+          <div className="dock-pop-chips">
+            <button className="dock-chip all" onClick={() => { onRegionSelect(null); setOpen(null); }}>All Sweden</button>
+            {operators.map(op => (
+              <button
+                key={op.slug}
+                className={`dock-chip ${activeOperators.includes(op.slug) ? 'active' : ''}`}
+                onClick={() => { onRegionSelect(op.slug); setOpen(null); }}
+                title={op.region}
+              >{op.name}</button>
+            ))}
+          </div>
+        </div>
+      )}
+      {open === 'lines' && (
+        <div className="dock-pop">
+          <div className="dock-pop-title">Filter by line</div>
+          <input className="dock-search" placeholder="Search lines…" value={search} onChange={e => setSearch(e.target.value)} />
+          <div className="dock-pop-chips scroll">
+            {Object.entries(lineOptions).flatMap(([mode, lines]) =>
+              lines.map(({ line }) => (
+                <button
+                  key={`${mode}:${line}`}
+                  className={`dock-chip ${isLineSelected(mode, line) ? 'active' : ''}`}
+                  style={{ '--accent': MODE_COLORS[mode] || '#888' }}
+                  onClick={() => onLineToggle(mode, line)}
+                >{line}</button>
+              )),
+            )}
+            {Object.keys(lineOptions).length === 0 && <span className="dock-empty">No matching lines</span>}
+          </div>
+        </div>
+      )}
+
+      <div className="dock">
+        <div className="dock-stats">
+          <div className="dock-stat"><b>{vehicles.length}</b><span>vehicles</span></div>
+          <div className="dock-stat"><b>{activeOperators.length}</b><span>operators</span></div>
+        </div>
+
+        <div className="dock-divider" />
+
+        <div className="dock-segment" role="group" aria-label="Transport modes">
+          {MODES.map(m => {
+            const on = enabledModes.includes(m.id);
+            return (
+              <button
+                key={m.id}
+                className={`dock-seg ${on ? 'on' : ''}`}
+                onClick={() => onModeToggle(m.id)}
+                style={on ? { background: m.color, borderColor: m.color, color: '#fff' } : {}}
+                title={`${m.label} (${stats[m.id] || 0})`}
+              >
+                {m.label}
+                <span className="dock-seg-count">{stats[m.id] || 0}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="dock-divider" />
+
+        <div className="dock-actions">
+          <button className={`dock-btn ${open === 'regions' ? 'open' : ''}`} onClick={() => toggle('regions')}>🌍 Regions</button>
+          <button className={`dock-btn ${open === 'lines' ? 'open' : ''}`} onClick={() => toggle('lines')}>
+            🚏 Lines{selectedLines.length > 0 && <span className="dock-badge">{selectedLines.length}</span>}
+          </button>
+          <button className={`dock-btn ${webcamsEnabled ? 'open' : ''}`} onClick={onWebcamsToggle}>
+            📷 Webcams{webcamsEnabled ? ` ${webcamCount}` : ''}
+          </button>
+          <button className="dock-btn icon" onClick={onRefresh} disabled={loading} title="Refresh">{loading ? '⟳' : '🔄'}</button>
+          <button className="dock-btn icon" onClick={onToggleTheme} title="Theme">{theme === 'dark' ? '☀' : '🌙'}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/prototype/VariantGlassHud.css
+++ b/src/components/prototype/VariantGlassHud.css
@@ -1,0 +1,93 @@
+/* PROTOTYPE — Variant A "Glass HUD". Frosted glass, neon accents. */
+.glass-hud {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  z-index: 1000;
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--chrome-bg) 70%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
+  backdrop-filter: blur(18px) saturate(160%);
+  border: 1px solid color-mix(in srgb, var(--chrome-text) 12%, transparent);
+  box-shadow: 0 12px 40px var(--chrome-shadow);
+  color: var(--chrome-text);
+  font-family: -apple-system, system-ui, sans-serif;
+}
+
+.glass-hud-top { display: flex; align-items: center; justify-content: space-between; }
+.glass-hud-title { display: flex; align-items: center; gap: 10px; }
+.glass-hud-title h2 { margin: 0; font-size: 16px; font-weight: 700; }
+.glass-hud-title small { color: var(--chrome-text-muted); font-size: 11px; }
+.glass-hud-pulse {
+  width: 10px; height: 10px; border-radius: 50%; background: #4ECDC4;
+  box-shadow: 0 0 0 0 #4ECDC4aa; animation: glassPulse 2s infinite;
+}
+@keyframes glassPulse {
+  0% { box-shadow: 0 0 0 0 #4ECDC4aa; }
+  70% { box-shadow: 0 0 0 8px #4ECDC400; }
+  100% { box-shadow: 0 0 0 0 #4ECDC400; }
+}
+.glass-hud-icon {
+  border: none; background: var(--chrome-hover-bg); border-radius: 10px;
+  width: 32px; height: 32px; cursor: pointer; font-size: 15px; color: var(--chrome-text);
+}
+
+.glass-hud-hero {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px; border-radius: 14px;
+  background: linear-gradient(135deg, color-mix(in srgb, #4ECDC4 22%, transparent), transparent);
+}
+.glass-hud-metric { display: flex; flex-direction: column; flex: 1; }
+.glass-hud-num { font-size: 30px; font-weight: 800; line-height: 1; letter-spacing: -1px; }
+.glass-hud-cap { font-size: 11px; color: var(--chrome-text-muted); text-transform: uppercase; letter-spacing: 1px; }
+.glass-hud-refresh {
+  width: 42px; height: 42px; border-radius: 50%; border: none; cursor: pointer;
+  background: #4ECDC4; color: #fff; font-size: 20px;
+}
+.glass-hud-refresh:disabled { opacity: .6; animation: spin 1s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.glass-hud-modes { display: flex; flex-wrap: wrap; gap: 6px; }
+.glass-hud-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 999px; cursor: pointer; font-size: 12px; font-weight: 600;
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  border: 1.5px solid var(--chrome-border); transition: all .18s;
+}
+.glass-hud-pill:not(.on) { opacity: .55; }
+.glass-hud-dot { width: 8px; height: 8px; border-radius: 50%; }
+.glass-hud-pill-count { font-size: 11px; opacity: .8; }
+
+.glass-hud-layer { display: flex; align-items: center; gap: 8px; font-size: 13px; cursor: pointer; }
+
+.glass-hud-regions { display: flex; flex-wrap: wrap; gap: 5px; }
+.glass-hud-region {
+  padding: 3px 10px; border-radius: 999px; font-size: 11px; cursor: pointer;
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  border: 1.5px solid var(--chrome-border);
+}
+.glass-hud-region.all { border-color: #4ECDC4; color: #45b8af; font-weight: 700; }
+.glass-hud-region.active { border-color: #4ECDC4; background: var(--chrome-chip-selected-bg); font-weight: 600; }
+
+.glass-hud-lines { display: flex; flex-direction: column; gap: 8px; }
+.glass-hud-search {
+  width: 100%; box-sizing: border-box; padding: 9px 12px; border-radius: 10px;
+  border: 1px solid var(--chrome-border); background: var(--chrome-chip-bg); color: var(--chrome-text);
+  font-size: 13px; outline: none;
+}
+.glass-hud-search:focus { border-color: #4ECDC4; }
+.glass-hud-clear { background: none; border: none; color: var(--chrome-text-muted); font-size: 12px; cursor: pointer; text-align: left; }
+.glass-hud-line-scroll { max-height: 180px; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+.glass-hud-line-group { display: flex; flex-wrap: wrap; gap: 5px; }
+.glass-hud-chip {
+  padding: 3px 9px; border-radius: 8px; font-size: 12px; font-weight: 600; cursor: pointer;
+  background: var(--chrome-chip-bg); border: 1.5px solid var(--chrome-border); color: var(--chrome-text);
+}
+.glass-hud-chip.sel { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 18%, transparent); }
+.glass-hud-empty { color: var(--chrome-text-muted); font-size: 12px; padding: 6px 0; }
+.glass-hud-foot { font-size: 11px; color: var(--chrome-text-muted); text-align: center; }

--- a/src/components/prototype/VariantGlassHud.jsx
+++ b/src/components/prototype/VariantGlassHud.jsx
@@ -1,0 +1,123 @@
+// PROTOTYPE — Variant A "Glass HUD". Frosted vertical panel, hero stats,
+// glowing segmented mode pills. Structurally close to current but premium reskin.
+import { useState } from 'react';
+import './VariantGlassHud.css';
+import { MODES, MODE_COLORS, MODE_LABELS } from '../../services/modes';
+import { countByMode, filterLines } from './prototypeShared';
+
+export function VariantGlassHud(props) {
+  const {
+    vehicles = [], loading, lastUpdate, onRefresh,
+    enabledModes = [], onModeToggle,
+    availableLines = {}, isLineSelected = () => false, onLineToggle = () => {},
+    selectedLines = [], onClearLines = () => {},
+    operators = [], activeOperators = [], onRegionSelect = () => {},
+    effectiveInterval = 2000, theme, onToggleTheme,
+    webcamsEnabled, onWebcamsToggle, webcamCount = 0,
+  } = props;
+
+  const [search, setSearch] = useState('');
+  const stats = countByMode(vehicles);
+  const lineOptions = filterLines(availableLines, search);
+
+  return (
+    <div className="glass-hud">
+      <div className="glass-hud-top">
+        <div className="glass-hud-title">
+          <span className="glass-hud-pulse" />
+          <div>
+            <h2>Sweden Transit</h2>
+            <small>Live · every {effectiveInterval / 1000}s</small>
+          </div>
+        </div>
+        <button className="glass-hud-icon" onClick={onToggleTheme} aria-label="Toggle theme">
+          {theme === 'dark' ? '☀' : '🌙'}
+        </button>
+      </div>
+
+      <div className="glass-hud-hero">
+        <div className="glass-hud-metric">
+          <span className="glass-hud-num">{vehicles.length}</span>
+          <span className="glass-hud-cap">vehicles</span>
+        </div>
+        <div className="glass-hud-metric">
+          <span className="glass-hud-num">{activeOperators.length}</span>
+          <span className="glass-hud-cap">operators</span>
+        </div>
+        <button className="glass-hud-refresh" onClick={onRefresh} disabled={loading} title="Refresh now">
+          {loading ? '⟳' : '⟳'}
+        </button>
+      </div>
+
+      <div className="glass-hud-modes">
+        {MODES.map(m => {
+          const on = enabledModes.includes(m.id);
+          return (
+            <button
+              key={m.id}
+              className={`glass-hud-pill ${on ? 'on' : ''}`}
+              onClick={() => onModeToggle(m.id)}
+              style={on ? { '--accent': m.color, borderColor: m.color, boxShadow: `0 0 12px ${m.color}66` } : { '--accent': m.color }}
+            >
+              <span className="glass-hud-dot" style={{ background: m.color }} />
+              {m.label}
+              <span className="glass-hud-pill-count">{stats[m.id] || 0}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <label className="glass-hud-layer">
+        <input type="checkbox" checked={webcamsEnabled} onChange={onWebcamsToggle} />
+        <span>Webcams {webcamsEnabled ? `· ${webcamCount}` : ''}</span>
+      </label>
+
+      <div className="glass-hud-regions">
+        <button className="glass-hud-region all" onClick={() => onRegionSelect(null)}>All Sweden</button>
+        {operators.map(op => (
+          <button
+            key={op.slug}
+            className={`glass-hud-region ${activeOperators.includes(op.slug) ? 'active' : ''}`}
+            onClick={() => onRegionSelect(op.slug)}
+            title={op.region}
+          >
+            {op.name}
+          </button>
+        ))}
+      </div>
+
+      <div className="glass-hud-lines">
+        <input
+          className="glass-hud-search"
+          placeholder="🔍 Search lines…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        {selectedLines.length > 0 && (
+          <button className="glass-hud-clear" onClick={onClearLines}>Clear {selectedLines.length} selected</button>
+        )}
+        <div className="glass-hud-line-scroll">
+          {Object.entries(lineOptions).map(([mode, lines]) => (
+            <div key={mode} className="glass-hud-line-group">
+              {lines.map(({ line }) => (
+                <span
+                  key={`${mode}:${line}`}
+                  className={`glass-hud-chip ${isLineSelected(mode, line) ? 'sel' : ''}`}
+                  style={{ '--accent': MODE_COLORS[mode] || '#888' }}
+                  onClick={() => onLineToggle(mode, line)}
+                >
+                  {line}
+                </span>
+              ))}
+            </div>
+          ))}
+          {Object.keys(lineOptions).length === 0 && <div className="glass-hud-empty">No matching lines</div>}
+        </div>
+      </div>
+
+      {lastUpdate && (
+        <div className="glass-hud-foot">Updated {lastUpdate.toLocaleTimeString('sv-SE')}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/prototype/VariantIconRail.css
+++ b/src/components/prototype/VariantIconRail.css
@@ -1,0 +1,214 @@
+/* PROTOTYPE — Variant C "Icon Rail", Palantir-inspired.
+   Operational console aesthetic: hairline borders, sharp 2px corners, a steel-blue
+   accent, monospace readouts, uppercase micro-labels. Scoped palette below derives
+   from the app theme but pushes toward a denser, more neutral command-console look. */
+
+.rail-root {
+  /* light (rare for ops UIs, but kept usable) */
+  --pal-bg: #f7f8fa;
+  --pal-panel: #ffffff;
+  --pal-line: #d4d9e0;
+  --pal-line-soft: #e7eaef;
+  --pal-text: #1b2733;
+  --pal-muted: #5b6878;
+  --pal-faint: #8a96a6;
+  --pal-accent: #2f6fed;
+  --pal-accent-soft: rgba(47, 111, 237, 0.1);
+  --pal-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 1000;
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  font-family: -apple-system, system-ui, sans-serif;
+}
+
+[data-theme="dark"] .rail-root {
+  /* signature dark ops palette: near-black slate, steel-blue accent */
+  --pal-bg: #0b0e14;
+  --pal-panel: #11161f;
+  --pal-line: #232b38;
+  --pal-line-soft: #1a212c;
+  --pal-text: #c6d0dc;
+  --pal-muted: #7a8694;
+  --pal-faint: #545f6d;
+  --pal-accent: #4d9dff;
+  --pal-accent-soft: rgba(77, 157, 255, 0.12);
+}
+
+/* ── Rail ───────────────────────────────────────────────── */
+.rail {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  padding: 8px 6px;
+  border-radius: 2px;
+  background: var(--pal-panel);
+  border: 1px solid var(--pal-line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+}
+.rail-logo {
+  font-family: var(--pal-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: var(--pal-accent);
+  text-align: center;
+  padding: 4px 0 8px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--pal-line-soft);
+}
+.rail-spacer { flex: 1; min-height: 12px; }
+.rail-btn {
+  position: relative;
+  width: 38px; height: 38px;
+  border-radius: 2px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: transparent;
+  color: var(--pal-muted);
+  display: flex; align-items: center; justify-content: center;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.rail-btn:hover { background: var(--pal-accent-soft); color: var(--pal-text); }
+.rail-btn.active {
+  color: var(--pal-accent);
+  background: var(--pal-accent-soft);
+  border-color: color-mix(in srgb, var(--pal-accent) 45%, transparent);
+}
+.rail-btn:disabled { opacity: .5; cursor: default; }
+.rail-btn:focus-visible { outline: 2px solid var(--pal-accent); outline-offset: 1px; }
+.rail-glyph { font-size: 18px; line-height: 1; }
+.rail-glyph.spin { display: inline-block; animation: railspin 1s linear infinite; }
+@keyframes railspin { to { transform: rotate(360deg); } }
+.rail-dot {
+  position: absolute; top: 2px; right: 2px;
+  background: var(--pal-accent); color: #fff;
+  border-radius: 2px; font-family: var(--pal-mono);
+  font-size: 9px; min-width: 15px; height: 15px; padding: 0 3px;
+  display: flex; align-items: center; justify-content: center; font-weight: 700;
+}
+
+/* ── Flyout ─────────────────────────────────────────────── */
+.rail-flyout {
+  width: 286px;
+  border-radius: 2px;
+  background: var(--pal-panel);
+  border: 1px solid var(--pal-line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+  color: var(--pal-text);
+  overflow: hidden;
+  animation: railIn .15s ease;
+}
+@keyframes railIn { from { opacity: 0; transform: translateX(-6px); } to { opacity: 1; transform: none; } }
+
+.rail-status {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 12px;
+  background: var(--pal-bg);
+  border-bottom: 1px solid var(--pal-line);
+  font-family: var(--pal-mono);
+  font-size: 10.5px;
+  letter-spacing: .5px;
+  color: var(--pal-muted);
+}
+.rail-led { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.rail-led.live { background: #2ec27e; box-shadow: 0 0 6px #2ec27e; animation: railpulse 2s infinite; }
+.rail-led.busy { background: var(--pal-accent); box-shadow: 0 0 6px var(--pal-accent); }
+@keyframes railpulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+.rail-status-text { color: var(--pal-text); font-weight: 600; }
+.rail-status-clock { margin-left: auto; color: var(--pal-faint); }
+
+.rail-flyout h3 {
+  margin: 0; padding: 12px 14px 10px;
+  font-family: var(--pal-mono);
+  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.2px;
+  color: var(--pal-faint);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.rail-clear {
+  background: none; border: 1px solid var(--pal-line); border-radius: 2px;
+  color: var(--pal-muted); font-family: var(--pal-mono); font-size: 10px; letter-spacing: .5px;
+  cursor: pointer; padding: 2px 6px;
+}
+.rail-clear:hover { border-color: var(--pal-accent); color: var(--pal-accent); }
+
+/* Overview readout */
+.rail-readout {
+  display: grid; grid-template-columns: 1fr 1fr;
+  border-top: 1px solid var(--pal-line-soft);
+  border-bottom: 1px solid var(--pal-line-soft);
+}
+.rail-readout-cell {
+  padding: 12px 14px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.rail-readout-cell + .rail-readout-cell { border-left: 1px solid var(--pal-line-soft); }
+.rail-readout-num {
+  font-family: var(--pal-mono); font-size: 30px; font-weight: 700;
+  line-height: 1; letter-spacing: -1px; color: var(--pal-text);
+}
+.rail-readout-cap {
+  font-size: 10px; text-transform: uppercase; letter-spacing: .8px; color: var(--pal-faint);
+}
+
+.rail-modebars { padding: 12px 14px; display: flex; flex-direction: column; gap: 9px; }
+.rail-bar { display: flex; align-items: center; gap: 9px; font-size: 11px; }
+.rail-bar-label { width: 48px; color: var(--pal-muted); text-transform: uppercase; letter-spacing: .4px; font-size: 10px; }
+.rail-bar-track { flex: 1; height: 4px; background: var(--pal-line-soft); overflow: hidden; }
+.rail-bar-fill { height: 100%; }
+.rail-bar-num { width: 30px; text-align: right; font-family: var(--pal-mono); font-weight: 600; color: var(--pal-text); }
+
+/* Mode / layer rows */
+.rail-modelist { padding: 6px; display: flex; flex-direction: column; }
+.rail-mode {
+  display: flex; align-items: center; gap: 10px; width: 100%;
+  padding: 9px 10px; border: none; border-radius: 2px; cursor: pointer;
+  background: transparent; color: var(--pal-text); font-size: 13px; text-align: left;
+  transition: background .12s;
+}
+.rail-mode:hover { background: var(--pal-accent-soft); }
+.rail-mode:not(.on) { opacity: .55; }
+.rail-swatch { width: 10px; height: 10px; flex-shrink: 0; }
+.rail-mode-name { flex: 1; font-weight: 600; }
+.rail-mode-count { font-family: var(--pal-mono); font-size: 11px; color: var(--pal-muted); }
+.rail-toggle {
+  width: 30px; height: 16px; border-radius: 2px; background: var(--pal-line);
+  position: relative; transition: background .15s; flex-shrink: 0;
+}
+.rail-toggle::after {
+  content: ''; position: absolute; top: 2px; left: 2px; width: 12px; height: 12px;
+  border-radius: 1px; background: var(--pal-faint); transition: transform .15s, background .15s;
+}
+.rail-toggle.on { background: var(--pal-accent-soft); }
+.rail-toggle.on::after { transform: translateX(14px); background: var(--pal-accent); }
+
+/* Chips */
+.rail-chips { display: flex; flex-wrap: wrap; gap: 5px; padding: 4px 14px 14px; }
+.rail-chips.scroll { max-height: 230px; overflow-y: auto; }
+.rail-chip {
+  padding: 4px 9px; border-radius: 2px; font-family: var(--pal-mono);
+  font-size: 11px; font-weight: 600; cursor: pointer; letter-spacing: .3px;
+  background: var(--pal-bg); border: 1px solid var(--pal-line); color: var(--pal-text);
+  transition: border-color .12s, background .12s;
+}
+.rail-chip:hover { border-color: var(--pal-muted); }
+.rail-chip.all { border-color: var(--pal-accent); color: var(--pal-accent); }
+.rail-chip.active {
+  border-color: var(--accent, var(--pal-accent));
+  background: color-mix(in srgb, var(--accent, var(--pal-accent)) 16%, transparent);
+  color: var(--pal-text);
+}
+.rail-search {
+  width: calc(100% - 28px); margin: 0 14px 10px; box-sizing: border-box;
+  padding: 8px 10px; border-radius: 2px; border: 1px solid var(--pal-line);
+  background: var(--pal-bg); color: var(--pal-text);
+  font-family: var(--pal-mono); font-size: 12px; letter-spacing: .5px; outline: none;
+}
+.rail-search::placeholder { color: var(--pal-faint); }
+.rail-search:focus { border-color: var(--pal-accent); }
+.rail-empty { color: var(--pal-faint); font-size: 12px; padding: 4px 0; }

--- a/src/components/prototype/VariantIconRail.jsx
+++ b/src/components/prototype/VariantIconRail.jsx
@@ -1,0 +1,171 @@
+// PROTOTYPE — Variant C "Icon Rail", Palantir-inspired operational reskin.
+// A thin vertical rail of icons; each opens a contextual flyout. Dense, technical,
+// monospace readouts, hairline borders, uppercase micro-labels — a command-console
+// feel rather than a friendly widget panel.
+import { useState } from 'react';
+import './VariantIconRail.css';
+import { MODES, MODE_COLORS } from '../../services/modes';
+import { countByMode, filterLines } from './prototypeShared';
+
+export function VariantIconRail(props) {
+  const {
+    vehicles = [], loading, lastUpdate, onRefresh,
+    enabledModes = [], onModeToggle,
+    availableLines = {}, isLineSelected = () => false, onLineToggle = () => {},
+    selectedLines = [], onClearLines = () => {},
+    operators = [], activeOperators = [], onRegionSelect = () => {},
+    effectiveInterval = 2000, theme, onToggleTheme,
+    webcamsEnabled, onWebcamsToggle, webcamCount = 0,
+  } = props;
+
+  const [panel, setPanel] = useState('stats'); // open by default so it's not empty
+  const [search, setSearch] = useState('');
+  const stats = countByMode(vehicles);
+  const lineOptions = filterLines(availableLines, search);
+  const sel = (p) => setPanel(cur => (cur === p ? null : p));
+
+  const RAIL = [
+    { id: 'stats', icon: '◧', label: 'Overview' },
+    { id: 'modes', icon: '◈', label: 'Modes' },
+    { id: 'regions', icon: '⬡', label: 'Regions' },
+    { id: 'lines', icon: '≣', label: 'Lines', badge: selectedLines.length },
+    { id: 'layers', icon: '⊞', label: 'Layers' },
+  ];
+
+  return (
+    <div className="rail-root">
+      <nav className="rail" aria-label="Control rail">
+        <div className="rail-logo" title="Sweden Real-Time Transit">STT</div>
+        {RAIL.map(item => (
+          <button
+            key={item.id}
+            className={`rail-btn ${panel === item.id ? 'active' : ''}`}
+            onClick={() => sel(item.id)}
+            title={item.label}
+            aria-label={item.label}
+            aria-pressed={panel === item.id}
+          >
+            <span className="rail-glyph">{item.icon}</span>
+            {item.badge > 0 && <span className="rail-dot">{item.badge}</span>}
+          </button>
+        ))}
+        <div className="rail-spacer" />
+        <button className="rail-btn" onClick={onRefresh} disabled={loading} title="Refresh feed">
+          <span className={`rail-glyph ${loading ? 'spin' : ''}`}>⟳</span>
+        </button>
+        <button className="rail-btn" onClick={onToggleTheme} title="Toggle theme" aria-label="Toggle theme">
+          <span className="rail-glyph">{theme === 'dark' ? '☀' : '☾'}</span>
+        </button>
+      </nav>
+
+      {panel && (
+        <section className="rail-flyout" aria-label={RAIL.find(r => r.id === panel)?.label}>
+          <div className="rail-status">
+            <span className={`rail-led ${loading ? 'busy' : 'live'}`} />
+            <span className="rail-status-text">
+              {loading ? 'SYNC' : 'LIVE'} · {(effectiveInterval / 1000).toFixed(1)}S · {activeOperators.length} OPR
+            </span>
+            <span className="rail-status-clock">{lastUpdate ? lastUpdate.toLocaleTimeString('sv-SE') : '—'}</span>
+          </div>
+
+          {panel === 'stats' && (
+            <>
+              <h3>Overview</h3>
+              <div className="rail-readout">
+                <div className="rail-readout-cell">
+                  <span className="rail-readout-num">{String(vehicles.length).padStart(3, '0')}</span>
+                  <span className="rail-readout-cap">Vehicles tracked</span>
+                </div>
+                <div className="rail-readout-cell">
+                  <span className="rail-readout-num">{String(activeOperators.length).padStart(2, '0')}</span>
+                  <span className="rail-readout-cap">Active operators</span>
+                </div>
+              </div>
+              <div className="rail-modebars">
+                {MODES.filter(m => stats[m.id]).map(m => {
+                  const pct = Math.round((stats[m.id] / Math.max(1, vehicles.length)) * 100);
+                  return (
+                    <div key={m.id} className="rail-bar">
+                      <span className="rail-bar-label">{m.label}</span>
+                      <div className="rail-bar-track"><div className="rail-bar-fill" style={{ width: `${pct}%`, background: m.color }} /></div>
+                      <span className="rail-bar-num">{String(stats[m.id]).padStart(3, ' ')}</span>
+                    </div>
+                  );
+                })}
+                {vehicles.length === 0 && <div className="rail-empty">No vehicles in viewport</div>}
+              </div>
+            </>
+          )}
+
+          {panel === 'modes' && (
+            <>
+              <h3>Transport modes</h3>
+              <div className="rail-modelist">
+                {MODES.map(m => {
+                  const on = enabledModes.includes(m.id);
+                  return (
+                    <button key={m.id} className={`rail-mode ${on ? 'on' : ''}`} onClick={() => onModeToggle(m.id)} aria-pressed={on}>
+                      <span className="rail-swatch" style={{ background: m.color }} />
+                      <span className="rail-mode-name">{m.label}</span>
+                      <span className="rail-mode-count">{String(stats[m.id] || 0).padStart(3, '0')}</span>
+                      <span className={`rail-toggle ${on ? 'on' : ''}`} />
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {panel === 'regions' && (
+            <>
+              <h3>Regions</h3>
+              <div className="rail-chips">
+                <button className="rail-chip all" onClick={() => onRegionSelect(null)}>ALL SWEDEN</button>
+                {operators.map(op => (
+                  <button
+                    key={op.slug}
+                    className={`rail-chip ${activeOperators.includes(op.slug) ? 'active' : ''}`}
+                    onClick={() => onRegionSelect(op.slug)}
+                    title={op.region}
+                  >{op.name}</button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {panel === 'lines' && (
+            <>
+              <h3>Filter · line{selectedLines.length > 0 && <button className="rail-clear" onClick={onClearLines}>CLR {selectedLines.length}</button>}</h3>
+              <input className="rail-search" placeholder="QUERY LINES…" value={search} onChange={e => setSearch(e.target.value)} />
+              <div className="rail-chips scroll">
+                {Object.entries(lineOptions).flatMap(([mode, lines]) =>
+                  lines.map(({ line }) => (
+                    <button
+                      key={`${mode}:${line}`}
+                      className={`rail-chip ${isLineSelected(mode, line) ? 'active' : ''}`}
+                      style={{ '--accent': MODE_COLORS[mode] || '#888' }}
+                      onClick={() => onLineToggle(mode, line)}
+                    >{line}</button>
+                  )),
+                )}
+                {Object.keys(lineOptions).length === 0 && <span className="rail-empty">No matching lines</span>}
+              </div>
+            </>
+          )}
+
+          {panel === 'layers' && (
+            <>
+              <h3>Layers</h3>
+              <button className={`rail-mode ${webcamsEnabled ? 'on' : ''}`} onClick={onWebcamsToggle} aria-pressed={webcamsEnabled}>
+                <span className="rail-swatch" style={{ background: '#2c3e50' }} />
+                <span className="rail-mode-name">Webcams</span>
+                <span className="rail-mode-count">{webcamsEnabled ? String(webcamCount).padStart(3, '0') : '—'}</span>
+                <span className={`rail-toggle ${webcamsEnabled ? 'on' : ''}`} />
+              </button>
+            </>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/prototype/prototypeShared.js
+++ b/src/components/prototype/prototypeShared.js
@@ -1,0 +1,27 @@
+// PROTOTYPE — throwaway. Shared helpers for the fancy ControlPanel variants.
+// Answers: "what should a fancier interface look like?" (sub-shape A, ?variant=).
+// Delete this whole prototype/ folder once a variant wins. See NOTES.md.
+import { MODE_LABELS } from '../../services/modes';
+
+/** Count vehicles per mode. */
+export function countByMode(vehicles = []) {
+  return vehicles.reduce((acc, v) => {
+    acc[v.mode] = (acc[v.mode] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+/** Filter the available-lines map by a free-text query (line number or mode name). */
+export function filterLines(availableLines = {}, query = '') {
+  const q = query.trim().toLowerCase();
+  if (!q) return availableLines;
+  const out = {};
+  for (const [mode, lines] of Object.entries(availableLines)) {
+    const modeLabel = (MODE_LABELS[mode] || mode).toLowerCase();
+    const matching = lines.filter(
+      ({ line }) => line.toLowerCase().includes(q) || modeLabel.includes(q),
+    );
+    if (matching.length > 0) out[mode] = matching;
+  }
+  return out;
+}


### PR DESCRIPTION
Integrates the prototype control-panel UI from `prototype/palantir-control-panel` into `develop`.

Adds 11 dev-only prototype files under `src/components/prototype/` (FancyControlPanel + Variant{GlassHud,IconRail,CommandDock}, PrototypeSwitcher, shared helpers) wired into App.jsx behind a clearly-marked "PROTOTYPE — dev-only, remove with src/components/prototype/" boundary. The geolocation lineage palantir built on is already in develop (#154), so only the prototype UI is new — no doc/geolocation conflicts.

**Gates:** 529 tests pass (41 files), build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)