### PR TITLE
Ponytail UI-wiring simplification

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,10 +39,8 @@ function App() {
     [cameras, enabledCameraTypes],
   );
 
-  const visibleOperators = useMemo(() => {
-    if (!viewportBounds) return ['sl'];
-    return getVisibleOperators(viewportBounds);
-  }, [viewportBounds]);
+  // ponytail: trivial derivation, no memo needed
+  const visibleOperators = viewportBounds ? getVisibleOperators(viewportBounds) : ['sl'];
 
   const { vehicles: allVehicles, feedOutcomes, error, loading, lastUpdate, refresh, activeOperators, effectiveInterval } =
     useRealtimeVehicles(visibleOperators, 2000, isOnline);
@@ -60,10 +58,6 @@ function App() {
     availableLines,
     filteredVehicles,
   } = useFilterSelection(allVehicles);
-
-  const handleBoundsChange = (bounds) => {
-    setViewportBounds(bounds);
-  };
 
   const handleCameraTypeToggle = (typeId) => {
     setEnabledCameraTypes(prev =>
@@ -119,7 +113,7 @@ function App() {
         cameras={webcamsEnabled ? filteredCameras : []}
         center={mapCenter}
         zoom={mapZoom}
-        onBoundsChange={handleBoundsChange}
+        onBoundsChange={setViewportBounds}
         theme={theme}
       />
       <ControlPanel

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -2,8 +2,6 @@ import { useState, useMemo } from 'react';
 import './ControlPanel.css';
 import { MODES, MODE_COLORS as MODE_COLOR_MAP, MODE_LABELS as MODE_LABEL_MAP } from '../services/modes';
 
-const TRANSPORT_MODES = MODES;
-
 // Display names for webcam source slugs in partial-failure warnings.
 const SOURCE_LABELS = {
   trafikverket: 'Trafikverket',
@@ -182,7 +180,7 @@ export function ControlPanel({
 
           <div className="mode-filters">
             <h3>Transport Modes</h3>
-            {TRANSPORT_MODES.map(mode => (
+            {MODES.map(mode => (
               <label key={mode.id} className="mode-filter">
                 <input
                   type="checkbox"


### PR DESCRIPTION
Integrates the `phassle-ponytail-repo-pass` cleanup (commit fa7fd89) into develop.

Three harmless micro-simplifications:
- App.jsx: inline `visibleOperators` (drop a trivial memo) — safe, since `useRealtimeVehicles` keys on a sorted `operatorKey` string, not array identity.
- App.jsx: pass `setViewportBounds` directly instead of a wrapper.
- ControlPanel.jsx: use `MODES` directly, drop the `TRANSPORT_MODES` alias.

**Gates:** 529 tests pass, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)