### PR TITLE
Release 1.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Keys from https://developer.trafiklab.se/. Rate limit: Bronze, 50 calls/min — 
 - [docs/adr/0002-dark-mode-tile-provider.md](docs/adr/0002-dark-mode-tile-provider.md) — why CartoDB Dark Matter for dark tiles
 - [docs/adr/0003-client-side-incident-derivation.md](docs/adr/0003-client-side-incident-derivation.md) — why the Command Center derives everything client-side, no backend
 - [docs/adr/0004-webcam-layer-static-images-no-embeds.md](docs/adr/0004-webcam-layer-static-images-no-embeds.md) — webcam embed boundary (hotlinked stills, no third-party embeds)
+- [docs/adr/0005-geolocation-ephemeral-client-only.md](docs/adr/0005-geolocation-ephemeral-client-only.md) — "locate me" position is ephemeral/client-only, never stored or sent
 - [docs/agents/domain.md](docs/agents/domain.md) — how agents consume CONTEXT.md + ADRs
 - [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md) — GitHub issue conventions via `gh`
 - [docs/agents/triage-labels.md](docs/agents/triage-labels.md) — triage label vocabulary

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,12 @@ The current canonical modes are: `metro | bus | train | tram | ferry | unknown`.
 
 `ship` is not a mode: no GTFS `route_type` in the Swedish feeds maps to it. Route type 1000 (Water Transport) maps to `ferry`.
 
+## User location
+
+The map position acquired from the browser's native geolocation, shown as a single "you are here" marker. A User location is **not** a Vehicle: it carries no line, mode, or operator, is styled as a distinct accent (never a transport-mode colour), and never enters the keyed marker-collection — it is one circle marker managed directly in `Map.jsx`. It is a **session-only singleton**: re-locating moves the one marker rather than accumulating, and it is forgotten on reload. Avoid the synonyms "GPS pin" / "current location".
+
+All `navigator.geolocation` interaction lives behind the **`useGeolocation`** hook (`locate()`, `position`, `status`), where `status` is the discriminated enum `idle | locating | success | denied | unavailable` (`denied` = the user declined; `unavailable` = no API / insecure origin — never conflated). The position is **ephemeral and client-only** ([ADR 0005](docs/adr/0005-geolocation-ephemeral-client-only.md)): held in memory only, never written to client storage and never sent to any service, so the browser-native permission prompt is the only gate — no Consent surface and no Privacy Notice change.
+
 ## Filter-selection module
 
 Filter state — enabled modes, selected lines, and the mode/line invariant — is owned entirely by **`src/hooks/useFilterSelection.js`**. No consumer builds or parses selection keys; the hook exposes `{mode, line}` objects and an `isLineSelected(mode, line)` predicate.

--- a/docs/adr/0005-geolocation-ephemeral-client-only.md
+++ b/docs/adr/0005-geolocation-ephemeral-client-only.md
@@ -1,0 +1,42 @@
+# ADR 0005 — Geolocation is ephemeral and client-only
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+
+## Context
+
+The "locate me" feature (PRD #111, first slice #112) acquires the user's position from the browser's native geolocation API to centre the map on where they are. A position is the most identifying data this app handles: it is personal data, and a history of positions would be a record of where the user has physically been.
+
+The app's privacy posture ([ADR 0001](0001-cookieless-no-consent-popup.md)) is cookieless with a Privacy Notice and **no** Consent surface, on the strict condition that the app performs no non-essential storage and no third-party processing of personal data. Persisting the user's location across visits, or sending coordinates to any non-tile service (reverse geocoding, nearest-stop lookup), would be exactly the kind of non-essential processing that reverses ADR 0001 and obliges a real Consent gate.
+
+The browser already provides a native permission prompt for geolocation — a familiar, OS-level, revocable gate that the user trusts.
+
+## Decision
+
+The User location is **ephemeral and client-only**:
+
+- It is held in React state only (the `useGeolocation` hook), for the duration of the session, and forgotten on reload.
+- It is **never** written to client storage (no `localStorage`, no cookie, no IndexedDB).
+- It is **never** sent to any service. The only network effect of locating is that moving the map viewport triggers the operators-in-viewport feed fetch the app already performs — those calls carry the viewport, not the user's coordinates.
+- Permission is governed **solely** by the browser-native prompt. The app adds no custom consent dialog and makes no Privacy Notice change.
+
+## Rationale
+
+- **Keeps ADR 0001 standing.** No non-essential storage and no third-party coordinate sharing are introduced, so the cookieless Privacy-Notice posture survives intact and no Consent surface is required.
+- **Native prompt is the right gate.** Geolocation is the one capability browsers already gate with a trusted, revocable permission; re-implementing consent in-app would be redundant and less trustworthy.
+- **Least data held.** Using the position in the moment and forgetting it means the app cannot build a location history even accidentally.
+
+## Trade-offs
+
+- The user re-grants (or the browser re-confirms) on each fresh visit; there is no "remember my location". This is intentional — story 13 ("no memory of my previous location") is a feature, not a gap.
+- A future "last location" convenience would require persisting a position, which is non-essential storage: it triggers the ADR 0001 reversal and must stand up a Consent surface first.
+
+## Reversal trigger
+
+Persisting the User location across reloads/visits, or sending coordinates to any non-tile service, reverses this decision and ADR 0001 together: the project must then ship the full Consent surface ADR 0001 prescribes, and the location feature lives behind that consent — never before it.
+
+## Related
+
+- [ADR 0001](0001-cookieless-no-consent-popup.md) — cookieless app, Privacy Notice not Consent gate; defines the reversal trigger this ADR avoids.
+- [CONTEXT.md](../../CONTEXT.md) — **User location** glossary term.
+- PRD: `#111` — Geolocation, "locate me" centres the map. First slice: `#112`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "real-time-transit-tracker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "real-time-transit-tracker",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@vitejs/plugin-react": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-time-transit-tracker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Map } from './components/Map';
 import { CommandCenter } from './components/CommandCenter';
 import { ControlPanel } from './components/ControlPanel';
+import { LocateControl } from './components/LocateControl';
 import { OfflineBanner } from './components/OfflineBanner';
 import { UpdateToast } from './components/UpdateToast';
 import { PrivacyNotice } from './components/PrivacyNotice';
@@ -9,6 +10,7 @@ import { useRealtimeVehicles } from './hooks/useRealtimeVehicles';
 import { useFilterSelection } from './hooks/useFilterSelection';
 import { useTheme } from './hooks/useTheme';
 import { useConnectivity } from './hooks/useConnectivity';
+import { useGeolocation } from './hooks/useGeolocation';
 import { useUpdatePrompt } from './hooks/useUpdatePrompt';
 import { useWebcams } from './hooks/useWebcams';
 import {
@@ -21,6 +23,7 @@ import { OPERATORS, OPERATOR_MAP, SWEDEN_CENTER, SWEDEN_ZOOM, getVisibleOperator
 function App() {
   const { theme, toggleTheme } = useTheme();
   const { isOnline } = useConnectivity();
+  const { locate, position: userLocation, status: geolocationStatus } = useGeolocation();
   const { needRefresh, updateServiceWorker, dismissUpdate } = useUpdatePrompt();
   const [mapCenter, setMapCenter] = useState([59.3293, 18.0686]);
   const [mapZoom, setMapZoom] = useState(11);
@@ -30,6 +33,17 @@ function App() {
   const [enabledCameraTypes, setEnabledCameraTypes] = useState(
     CAMERA_TYPE_DEFINITIONS.map(t => t.id),
   );
+
+  // Fly to the User location when a fix arrives, at city-level zoom (~12).
+  // This reuses the existing center/zoom → Map flyTo seam; moving the viewport
+  // also triggers the viewport→operators fetch, so the user's region loads
+  // its vehicles with no geolocation-specific polling code (PRD #111).
+  useEffect(() => {
+    if (userLocation) {
+      setMapCenter([userLocation.latitude, userLocation.longitude]);
+      setMapZoom(12);
+    }
+  }, [userLocation]);
 
   const { cameras, error: webcamsError, errors: webcamsErrors, loading: webcamsLoading } = useWebcams(webcamsEnabled);
 
@@ -121,6 +135,7 @@ function App() {
         zoom={mapZoom}
         onBoundsChange={handleBoundsChange}
         theme={theme}
+        userLocation={userLocation}
       />
       <ControlPanel
         vehicles={filteredVehicles}
@@ -155,6 +170,7 @@ function App() {
         cameraCounts={cameraCounts}
         onCameraTypeToggle={handleCameraTypeToggle}
       />
+      <LocateControl status={geolocationStatus} onLocate={locate} />
       <OfflineBanner isOnline={isOnline} />
       <UpdateToast isVisible={needRefresh} onReload={updateServiceWorker} onDismiss={dismissUpdate} />
       <PrivacyNotice />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -170,7 +170,7 @@ function App() {
         cameraCounts={cameraCounts}
         onCameraTypeToggle={handleCameraTypeToggle}
       />
-      <LocateControl status={geolocationStatus} onLocate={locate} />
+      <LocateControl status={geolocationStatus} onLocate={locate} theme={theme} />
       <OfflineBanner isOnline={isOnline} />
       <UpdateToast isVisible={needRefresh} onReload={updateServiceWorker} onDismiss={dismissUpdate} />
       <PrivacyNotice />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,9 @@ import { useState, useMemo, useEffect } from 'react';
 import { Map } from './components/Map';
 import { CommandCenter } from './components/CommandCenter';
 import { ControlPanel } from './components/ControlPanel';
+// PROTOTYPE — fancy-interface variants, dev-only. Remove with src/components/prototype/. See NOTES.md.
+import { FancyControlPanel } from './components/prototype/FancyControlPanel';
+const PanelComponent = import.meta.env.DEV ? FancyControlPanel : ControlPanel;
 import { LocateControl } from './components/LocateControl';
 import { OfflineBanner } from './components/OfflineBanner';
 import { UpdateToast } from './components/UpdateToast';
@@ -137,7 +140,7 @@ function App() {
         theme={theme}
         userLocation={userLocation}
       />
-      <ControlPanel
+      <PanelComponent
         vehicles={filteredVehicles}
         loading={loading}
         error={error}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,10 +39,8 @@ function App() {
     [cameras, enabledCameraTypes],
   );
 
-  const visibleOperators = useMemo(() => {
-    if (!viewportBounds) return ['sl'];
-    return getVisibleOperators(viewportBounds);
-  }, [viewportBounds]);
+  // ponytail: trivial derivation, no memo needed
+  const visibleOperators = viewportBounds ? getVisibleOperators(viewportBounds) : ['sl'];
 
   const { vehicles: allVehicles, feedOutcomes, error, loading, lastUpdate, refresh, activeOperators, effectiveInterval } =
     useRealtimeVehicles(visibleOperators, 2000, isOnline);
@@ -60,10 +58,6 @@ function App() {
     availableLines,
     filteredVehicles,
   } = useFilterSelection(allVehicles);
-
-  const handleBoundsChange = (bounds) => {
-    setViewportBounds(bounds);
-  };
 
   const handleCameraTypeToggle = (typeId) => {
     setEnabledCameraTypes(prev =>
@@ -119,7 +113,7 @@ function App() {
         cameras={webcamsEnabled ? filteredCameras : []}
         center={mapCenter}
         zoom={mapZoom}
-        onBoundsChange={handleBoundsChange}
+        onBoundsChange={setViewportBounds}
         theme={theme}
       />
       <ControlPanel

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -2,8 +2,6 @@ import { useState, useMemo } from 'react';
 import './ControlPanel.css';
 import { MODES, MODE_COLORS as MODE_COLOR_MAP, MODE_LABELS as MODE_LABEL_MAP } from '../services/modes';
 
-const TRANSPORT_MODES = MODES;
-
 // Display names for webcam source slugs in partial-failure warnings.
 const SOURCE_LABELS = {
   trafikverket: 'Trafikverket',
@@ -182,7 +180,7 @@ export function ControlPanel({
 
           <div className="mode-filters">
             <h3>Transport Modes</h3>
-            {TRANSPORT_MODES.map(mode => (
+            {MODES.map(mode => (
               <label key={mode.id} className="mode-filter">
                 <input
                   type="checkbox"

--- a/src/components/LocateControl.css
+++ b/src/components/LocateControl.css
@@ -1,0 +1,38 @@
+.locate-control {
+  position: absolute;
+  bottom: 24px;
+  right: 12px;
+  z-index: 1000;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  color: #1d6fe0;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
+}
+
+.locate-control:hover {
+  background: #f4f4f4;
+}
+
+.locate-control:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+[data-theme="dark"] .locate-control {
+  background: #1e1e2e;
+  color: #5b9dff;
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+[data-theme="dark"] .locate-control:hover {
+  background: #2a2a3e;
+}

--- a/src/components/LocateControl.css
+++ b/src/components/LocateControl.css
@@ -46,12 +46,15 @@
   }
 }
 
-[data-theme="dark"] .locate-control {
+/* Theme-aware styling (issue #115, story 15): keyed off the control's own
+   data-theme attribute (set from the active theme) rather than an ancestor, so
+   the button stays legible on dark tiles and the styling is self-contained. */
+.locate-control[data-theme="dark"] {
   background: #1e1e2e;
   color: #5b9dff;
   border-color: rgba(255, 255, 255, 0.25);
 }
 
-[data-theme="dark"] .locate-control:hover {
+.locate-control[data-theme="dark"]:hover {
   background: #2a2a3e;
 }

--- a/src/components/LocateControl.css
+++ b/src/components/LocateControl.css
@@ -27,6 +27,25 @@
   opacity: 0.6;
 }
 
+/* In-progress feedback while a fix is being acquired (issue #114, PRD #111
+   story 9): the busy glyph spins so the tap reads as registered and working.
+   Cleared automatically once status leaves locating — the modifier class is a
+   pure function of status === 'locating'. */
+.locate-control--busy {
+  animation: locate-control-spin 0.9s linear infinite;
+}
+
+@keyframes locate-control-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .locate-control--busy {
+    animation: none;
+  }
+}
+
 [data-theme="dark"] .locate-control {
   background: #1e1e2e;
   color: #5b9dff;

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -4,21 +4,34 @@ import './LocateControl.css';
 // zoom + view toggle). A thin presenter: it derives everything from the
 // useGeolocation status and holds no geolocation logic of its own.
 //
-// This slice (issue #112) covers idle → locating → success. The button shows a
-// pending state while locating and is otherwise tappable. denied/unavailable
-// tooltips and disabling land in a later slice.
+// Enabled state and tooltip are a pure mapping from status (issue #113). The two
+// non-success terminal states are kept distinct: denied (the user refused) and
+// unavailable (no capability — insecure origin / no API) get separate tooltips
+// so refusal is never conflated with absent capability.
+const TOOLTIP = {
+  idle: 'Locate me',
+  locating: 'Locate me',
+  success: 'Locate me',
+  denied: 'you declined location access',
+  unavailable: 'location is unavailable in this context',
+};
+
+const DISABLED = new Set(['locating', 'denied', 'unavailable']);
+
 export function LocateControl({ status = 'idle', onLocate }) {
   const locating = status === 'locating';
+  const disabled = DISABLED.has(status);
+  const title = TOOLTIP[status] ?? TOOLTIP.idle;
 
   return (
     <button
       type="button"
       className="locate-control"
       onClick={onLocate}
-      disabled={locating}
+      disabled={disabled}
       aria-label="Locate me"
       aria-busy={locating}
-      title="Locate me"
+      title={title}
     >
       {locating ? '…' : '◎'}
     </button>

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -8,6 +8,11 @@ import './LocateControl.css';
 // non-success terminal states are kept distinct: denied (the user refused) and
 // unavailable (no capability — insecure origin / no API) get separate tooltips
 // so refusal is never conflated with absent capability.
+//
+// In-progress feedback (issue #114, story 9): while status === 'locating' the
+// button is aria-busy and carries the --busy modifier (a spinning glyph), so a
+// tap visibly registers. It clears the moment status leaves locating — success,
+// denied, timeout, or unavailable all return the button to its resting state.
 const TOOLTIP = {
   idle: 'Locate me',
   locating: 'Locate me',
@@ -26,7 +31,7 @@ export function LocateControl({ status = 'idle', onLocate }) {
   return (
     <button
       type="button"
-      className="locate-control"
+      className={locating ? 'locate-control locate-control--busy' : 'locate-control'}
       onClick={onLocate}
       disabled={disabled}
       aria-label="Locate me"

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -1,0 +1,26 @@
+import './LocateControl.css';
+
+// "Locate me" map control, bottom-right (top-left = ControlPanel, top-right =
+// zoom + view toggle). A thin presenter: it derives everything from the
+// useGeolocation status and holds no geolocation logic of its own.
+//
+// This slice (issue #112) covers idle → locating → success. The button shows a
+// pending state while locating and is otherwise tappable. denied/unavailable
+// tooltips and disabling land in a later slice.
+export function LocateControl({ status = 'idle', onLocate }) {
+  const locating = status === 'locating';
+
+  return (
+    <button
+      type="button"
+      className="locate-control"
+      onClick={onLocate}
+      disabled={locating}
+      aria-label="Locate me"
+      aria-busy={locating}
+      title="Locate me"
+    >
+      {locating ? '…' : '◎'}
+    </button>
+  );
+}

--- a/src/components/LocateControl.jsx
+++ b/src/components/LocateControl.jsx
@@ -13,6 +13,11 @@ import './LocateControl.css';
 // button is aria-busy and carries the --busy modifier (a spinning glyph), so a
 // tap visibly registers. It clears the moment status leaves locating — success,
 // denied, timeout, or unavailable all return the button to its resting state.
+//
+// Theme-awareness (issue #115, story 15): the active theme is reflected as a
+// data-theme attribute on the button so its dark/light styling is self-contained
+// (CSS keys off .locate-control[data-theme="dark"]) and assertable at the RTL
+// level — no reliance on an ancestor [data-theme] for this control.
 const TOOLTIP = {
   idle: 'Locate me',
   locating: 'Locate me',
@@ -23,7 +28,7 @@ const TOOLTIP = {
 
 const DISABLED = new Set(['locating', 'denied', 'unavailable']);
 
-export function LocateControl({ status = 'idle', onLocate }) {
+export function LocateControl({ status = 'idle', onLocate, theme = 'light' }) {
   const locating = status === 'locating';
   const disabled = DISABLED.has(status);
   const title = TOOLTIP[status] ?? TOOLTIP.idle;
@@ -36,6 +41,7 @@ export function LocateControl({ status = 'idle', onLocate }) {
       disabled={disabled}
       aria-label="Locate me"
       aria-busy={locating}
+      data-theme={theme}
       title={title}
     >
       {locating ? '…' : '◎'}

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -49,4 +49,29 @@ describe('LocateControl', () => {
     const unavailableTitle = screen.getByRole('button', { name: /locat/i }).title;
     expect(deniedTitle).not.toBe(unavailableTitle);
   });
+
+  // Issue #114 / PRD #111 story 9 — in-progress feedback while acquiring the fix.
+  it('shows an in-progress busy indicator while locating', () => {
+    render(<LocateControl status="locating" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.getAttribute('aria-busy')).toBe('true');
+    expect(btn.className).toContain('locate-control--busy');
+  });
+
+  it('clears the in-progress indicator once a fix arrives', () => {
+    render(<LocateControl status="success" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.getAttribute('aria-busy')).toBe('false');
+    expect(btn.className).not.toContain('locate-control--busy');
+  });
+
+  it('clears the in-progress indicator if the request is denied or unavailable', () => {
+    for (const status of ['denied', 'unavailable', 'idle']) {
+      const { unmount } = render(<LocateControl status={status} onLocate={() => {}} />);
+      const btn = screen.getByRole('button', { name: /locat/i });
+      expect(btn.getAttribute('aria-busy')).toBe('false');
+      expect(btn.className).not.toContain('locate-control--busy');
+      unmount();
+    }
+  });
 });

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -74,4 +74,24 @@ describe('LocateControl', () => {
       unmount();
     }
   });
+
+  // Issue #115 / PRD #111 story 14 — keyboard / screen-reader accessibility.
+  it('is keyboard-focusable and exposes an accessible name describing "locate me"', () => {
+    render(<LocateControl status="idle" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locate me/i });
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+    // a native <button> activates on Enter/Space — keyboard activation routes to onClick.
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.disabled).toBe(false);
+  });
+
+  // Issue #115 / PRD #111 story 15 — button is theme-aware (legible per theme).
+  it('reflects the active theme so it can be styled legibly per theme', () => {
+    const { unmount } = render(<LocateControl status="idle" theme="dark" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locat/i }).getAttribute('data-theme')).toBe('dark');
+    unmount();
+    render(<LocateControl status="idle" theme="light" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locat/i }).getAttribute('data-theme')).toBe('light');
+  });
 });

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -26,4 +26,27 @@ describe('LocateControl', () => {
     render(<LocateControl status="success" onLocate={() => {}} />);
     expect(screen.getByRole('button', { name: /locate/i }).disabled).toBe(false);
   });
+
+  it('disables the button and explains the decline when permission is denied', () => {
+    render(<LocateControl status="denied" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toBe('you declined location access');
+  });
+
+  it('disables the button with a distinct tooltip when geolocation is unavailable', () => {
+    render(<LocateControl status="unavailable" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locat/i });
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toBe('location is unavailable in this context');
+  });
+
+  it('uses distinct tooltips for denied versus unavailable (never conflated)', () => {
+    const { unmount } = render(<LocateControl status="denied" onLocate={() => {}} />);
+    const deniedTitle = screen.getByRole('button', { name: /locat/i }).title;
+    unmount();
+    render(<LocateControl status="unavailable" onLocate={() => {}} />);
+    const unavailableTitle = screen.getByRole('button', { name: /locat/i }).title;
+    expect(deniedTitle).not.toBe(unavailableTitle);
+  });
 });

--- a/src/components/LocateControl.test.jsx
+++ b/src/components/LocateControl.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LocateControl } from './LocateControl';
+
+describe('LocateControl', () => {
+  it('renders a labelled, focusable button', () => {
+    render(<LocateControl status="idle" onLocate={() => {}} />);
+    const btn = screen.getByRole('button', { name: /locate/i });
+    expect(btn).toBeTruthy();
+    expect(btn.tagName).toBe('BUTTON');
+  });
+
+  it('calls onLocate when tapped', () => {
+    const onLocate = vi.fn();
+    render(<LocateControl status="idle" onLocate={onLocate} />);
+    fireEvent.click(screen.getByRole('button', { name: /locate/i }));
+    expect(onLocate).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button while a fix is being acquired', () => {
+    render(<LocateControl status="locating" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locat/i }).disabled).toBe(true);
+  });
+
+  it('is enabled again after a successful fix', () => {
+    render(<LocateControl status="success" onLocate={() => {}} />);
+    expect(screen.getByRole('button', { name: /locate/i }).disabled).toBe(false);
+  });
+});

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -9,9 +9,13 @@ import { createMarkerCollection } from '../services/markerCollection';
 import { createVehicleAdapter, FULL_MARKER_MIN_ZOOM } from '../services/vehicleAdapter';
 import { createWebcamAdapter } from '../services/webcamAdapter';
 
-export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = [] }) {
+export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = [], userLocation = null }) {
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
+  // Singleton User location marker (PRD #111). A single circle marker managed
+  // directly here — deliberately NOT routed through the keyed marker-collection,
+  // which exists for id-diffed collections. Re-locating moves this one marker.
+  const userMarkerRef = useRef(null);
   const vehicleCollectionRef = useRef(null);
   // Highlight set is read live by the adapter so selection changes are reflected.
   const highlightRef = useRef(new Set());
@@ -138,6 +142,27 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   useEffect(() => {
     webcamCollectionRef.current?.update(cameras, webcamAdapterRef.current);
   }, [cameras]);
+
+  // User location singleton: place once, then move on subsequent fixes. Styled
+  // as a distinct "you are here" blue accent — never a transport-mode colour —
+  // so it is never mistaken for a Vehicle.
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map || !userLocation) return;
+    const latlng = [userLocation.latitude, userLocation.longitude];
+    if (userMarkerRef.current) {
+      userMarkerRef.current.setLatLng(latlng);
+    } else {
+      userMarkerRef.current = L.circleMarker(latlng, {
+        radius: 8,
+        color: '#ffffff',
+        weight: 2,
+        fillColor: '#1d6fe0',
+        fillOpacity: 1,
+      }).addTo(map);
+      userMarkerRef.current.bindTooltip('You are here');
+    }
+  }, [userLocation]);
 
   return (
     <div

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -145,24 +145,29 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
 
   // User location singleton: place once, then move on subsequent fixes. Styled
   // as a distinct "you are here" blue accent — never a transport-mode colour —
-  // so it is never mistaken for a Vehicle.
+  // so it is never mistaken for a Vehicle. The accent is theme-aware (issue
+  // #115, story 15): a deeper blue on light tiles, a brighter blue on dark tiles
+  // (matching the locate button), so it stays legible against either basemap
+  // while keeping its distinct white-ringed accent. Restyled on theme change.
   useEffect(() => {
     const map = mapInstanceRef.current;
     if (!map || !userLocation) return;
     const latlng = [userLocation.latitude, userLocation.longitude];
+    const style = {
+      radius: 8,
+      color: '#ffffff',
+      weight: 2,
+      fillColor: theme === 'dark' ? '#5b9dff' : '#1d6fe0',
+      fillOpacity: 1,
+    };
     if (userMarkerRef.current) {
       userMarkerRef.current.setLatLng(latlng);
+      userMarkerRef.current.setStyle(style);
     } else {
-      userMarkerRef.current = L.circleMarker(latlng, {
-        radius: 8,
-        color: '#ffffff',
-        weight: 2,
-        fillColor: '#1d6fe0',
-        fillOpacity: 1,
-      }).addTo(map);
+      userMarkerRef.current = L.circleMarker(latlng, style).addTo(map);
       userMarkerRef.current.bindTooltip('You are here');
     }
-  }, [userLocation]);
+  }, [userLocation, theme]);
 
   return (
     <div

--- a/src/components/prototype/FancyControlPanel.jsx
+++ b/src/components/prototype/FancyControlPanel.jsx
@@ -1,0 +1,40 @@
+// PROTOTYPE — throwaway. Drop-in replacement for <ControlPanel> in dev that
+// renders one of several "fancy" variants, chosen by the ?variant= URL param,
+// with a floating switcher bar to flip between them. Hidden in production.
+//
+// Question being answered: "what should a fancier interface look like?"
+// Sub-shape A — same map route, only the panel rendering swaps. See NOTES.md.
+import { useEffect, useState } from 'react';
+import { ControlPanel } from '../ControlPanel';
+import { VariantGlassHud } from './VariantGlassHud';
+import { VariantCommandDock } from './VariantCommandDock';
+import { VariantIconRail } from './VariantIconRail';
+import { PrototypeSwitcher } from './PrototypeSwitcher';
+
+function useVariantParam() {
+  const read = () => new URLSearchParams(window.location.search).get('variant') || 'C';
+  const [variant, setVariant] = useState(read);
+  useEffect(() => {
+    const onChange = () => setVariant(read());
+    window.addEventListener('popstate', onChange);
+    return () => window.removeEventListener('popstate', onChange);
+  }, []);
+  return variant;
+}
+
+export function FancyControlPanel(props) {
+  const variant = useVariantParam();
+
+  let panel;
+  if (variant === 'B') panel = <VariantCommandDock {...props} />;
+  else if (variant === 'C') panel = <VariantIconRail {...props} />;
+  else if (variant === 'original') panel = <ControlPanel {...props} />;
+  else panel = <VariantGlassHud {...props} />;
+
+  return (
+    <>
+      {panel}
+      <PrototypeSwitcher current={variant} />
+    </>
+  );
+}

--- a/src/components/prototype/NOTES.md
+++ b/src/components/prototype/NOTES.md
@@ -1,0 +1,47 @@
+# PROTOTYPE — Fancier control panel
+
+**Question:** What should a fancier version of the map control panel look like?
+
+**Shape:** UI prototype, sub-shape A — same map route, only the panel rendering
+swaps via a `?variant=` URL param. Dev-only; production keeps the real
+`ControlPanel` (`App.jsx` gates on `import.meta.env.DEV`).
+
+## How to run
+
+```bash
+npm run dev   # http://localhost:3000
+```
+
+Flip variants with the floating pill at the bottom-centre, the ← / → keys, or by
+setting `?variant=A|B|C|original` in the URL. Toggle dark mode (🌙) — every
+variant is theme-aware via the existing `--chrome-*` CSS vars.
+
+## Variants (structurally different, not recolours)
+
+- **A — Glass HUD** (`VariantGlassHud`): frosted translucent left panel, hero
+  stat numbers, glowing segmented mode pills. Vertical, premium reskin.
+- **B — Command Dock** (`VariantCommandDock`): horizontal bar pinned to the
+  bottom. Stats inline left, segmented mode control as the hero, regions/lines
+  behind popovers that open upward.
+- **C — Icon Rail** (`VariantIconRail`): thin vertical icon rail; each icon
+  opens a contextual flyout. Hierarchy collapsed to icons; Overview flyout has
+  a mode-distribution bar chart.
+- **original**: the current `ControlPanel`, for side-by-side comparison.
+
+## Verdict
+
+**Winner: C — Icon Rail.** Per picked the rail + contextual-flyout structure and
+asked for a **Palantir-inspired** aesthetic. Variant C has been reskinned to a
+command-console look: hairline borders, sharp 2px corners, a steel-blue accent,
+monospace readouts, uppercase micro-labels, and a LIVE/SYNC status strip. It is
+now the default variant (`?variant=C`). Dark mode carries the signature
+near-black slate palette; light mode is a neutral usable fallback.
+
+Still open before production fold-in: re-add the **favourites stars** and
+**camera-type sub-filters** the prototype dropped, write tests, and replace the
+real `ControlPanel`. This PR ships the prototype for design sign-off only.
+
+## Files (all throwaway)
+
+- `src/components/prototype/` — variants, switcher, shared helpers, this file
+- `App.jsx` — the `PanelComponent` dev gate (3 added lines)

--- a/src/components/prototype/PrototypeSwitcher.css
+++ b/src/components/prototype/PrototypeSwitcher.css
@@ -1,0 +1,43 @@
+/* PROTOTYPE — throwaway. High-contrast pill so it's obviously not the design. */
+.proto-switcher {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  border-radius: 999px;
+  background: #111;
+  color: #fff;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+  font: 600 13px/1 -apple-system, system-ui, sans-serif;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.proto-switcher-label {
+  padding: 0 10px;
+  white-space: nowrap;
+}
+
+.proto-switcher-label strong {
+  color: #4ECDC4;
+}
+
+.proto-switcher-arrow {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.proto-switcher-arrow:hover {
+  background: rgba(255, 255, 255, 0.25);
+}

--- a/src/components/prototype/PrototypeSwitcher.jsx
+++ b/src/components/prototype/PrototypeSwitcher.jsx
@@ -1,0 +1,59 @@
+// PROTOTYPE — throwaway floating switcher. Hidden in production builds.
+import { useEffect } from 'react';
+import './PrototypeSwitcher.css';
+
+// Keep in sync with FancyControlPanel's variant map.
+const VARIANTS = [
+  { key: 'A', name: 'Glass HUD' },
+  { key: 'B', name: 'Command Dock' },
+  { key: 'C', name: 'Icon Rail · Palantir' },
+  { key: 'original', name: 'Original (current)' },
+];
+
+function setVariant(key) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('variant', key);
+  window.history.replaceState({}, '', url);
+  // No router in this SPA — nudge React via a popstate so the param re-reads.
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function PrototypeSwitcher({ current }) {
+  const idx = Math.max(0, VARIANTS.findIndex(v => v.key === current));
+  const cur = VARIANTS[idx];
+
+  useEffect(() => {
+    const onKey = (e) => {
+      const t = e.target;
+      const typing =
+        t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
+      if (typing) return;
+      if (e.key === 'ArrowLeft') setVariant(VARIANTS[(idx - 1 + VARIANTS.length) % VARIANTS.length].key);
+      if (e.key === 'ArrowRight') setVariant(VARIANTS[(idx + 1) % VARIANTS.length].key);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [idx]);
+
+  return (
+    <div className="proto-switcher" role="group" aria-label="Prototype variant switcher">
+      <button
+        className="proto-switcher-arrow"
+        onClick={() => setVariant(VARIANTS[(idx - 1 + VARIANTS.length) % VARIANTS.length].key)}
+        aria-label="Previous variant"
+      >
+        ‹
+      </button>
+      <span className="proto-switcher-label">
+        <strong>{cur.key}</strong> — {cur.name}
+      </span>
+      <button
+        className="proto-switcher-arrow"
+        onClick={() => setVariant(VARIANTS[(idx + 1) % VARIANTS.length].key)}
+        aria-label="Next variant"
+      >
+        ›
+      </button>
+    </div>
+  );
+}

--- a/src/components/prototype/VariantCommandDock.css
+++ b/src/components/prototype/VariantCommandDock.css
@@ -1,0 +1,87 @@
+/* PROTOTYPE — Variant B "Command Dock". Bottom horizontal command bar. */
+.dock-root {
+  position: absolute;
+  left: 50%;
+  bottom: 70px; /* clears the prototype switcher pill */
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  max-width: calc(100vw - 40px);
+  font-family: -apple-system, system-ui, sans-serif;
+}
+
+.dock {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--chrome-bg) 85%, transparent);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--chrome-border);
+  box-shadow: 0 10px 36px var(--chrome-shadow);
+  color: var(--chrome-text);
+}
+
+.dock-stats { display: flex; gap: 14px; }
+.dock-stat { display: flex; flex-direction: column; align-items: center; line-height: 1.1; }
+.dock-stat b { font-size: 20px; font-weight: 800; letter-spacing: -.5px; }
+.dock-stat span { font-size: 10px; color: var(--chrome-text-muted); text-transform: uppercase; letter-spacing: .5px; }
+
+.dock-divider { width: 1px; align-self: stretch; background: var(--chrome-border); }
+
+.dock-segment {
+  display: flex; gap: 0; border-radius: 10px; overflow: hidden;
+  border: 1px solid var(--chrome-border);
+}
+.dock-seg {
+  display: flex; align-items: center; gap: 5px;
+  padding: 7px 11px; border: none; border-right: 1px solid var(--chrome-border);
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  font-size: 12px; font-weight: 600; cursor: pointer; transition: all .15s;
+}
+.dock-seg:last-child { border-right: none; }
+.dock-seg:not(.on) { opacity: .5; }
+.dock-seg-count { font-size: 10px; opacity: .85; }
+
+.dock-actions { display: flex; align-items: center; gap: 6px; }
+.dock-btn {
+  position: relative;
+  padding: 7px 11px; border-radius: 10px; border: 1px solid var(--chrome-border);
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  font-size: 12px; font-weight: 600; cursor: pointer; white-space: nowrap;
+}
+.dock-btn.icon { padding: 7px 9px; font-size: 14px; }
+.dock-btn.open { border-color: #4ECDC4; background: var(--chrome-chip-selected-bg); }
+.dock-btn:disabled { opacity: .6; }
+.dock-badge {
+  margin-left: 5px; background: #4ECDC4; color: #fff; border-radius: 9px;
+  font-size: 10px; padding: 1px 6px;
+}
+
+.dock-pop {
+  width: min(520px, calc(100vw - 40px));
+  padding: 14px 16px; border-radius: 14px;
+  background: var(--chrome-bg); border: 1px solid var(--chrome-border);
+  box-shadow: 0 10px 36px var(--chrome-shadow); color: var(--chrome-text);
+}
+.dock-pop-title { font-size: 12px; font-weight: 700; color: var(--chrome-text-strong); margin-bottom: 10px; text-transform: uppercase; letter-spacing: .5px; }
+.dock-pop-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.dock-pop-chips.scroll { max-height: 160px; overflow-y: auto; }
+.dock-search {
+  width: 100%; box-sizing: border-box; padding: 8px 11px; margin-bottom: 10px;
+  border-radius: 9px; border: 1px solid var(--chrome-border);
+  background: var(--chrome-chip-bg); color: var(--chrome-text); font-size: 13px; outline: none;
+}
+.dock-search:focus { border-color: #4ECDC4; }
+.dock-chip {
+  padding: 4px 11px; border-radius: 999px; font-size: 12px; font-weight: 600; cursor: pointer;
+  background: var(--chrome-chip-bg); border: 1.5px solid var(--chrome-border); color: var(--chrome-text);
+}
+.dock-chip.all { border-color: #4ECDC4; color: #45b8af; }
+.dock-chip.active { border-color: var(--accent, #4ECDC4); background: var(--chrome-chip-selected-bg); }
+.dock-empty { color: var(--chrome-text-muted); font-size: 12px; }

--- a/src/components/prototype/VariantCommandDock.jsx
+++ b/src/components/prototype/VariantCommandDock.jsx
@@ -1,0 +1,106 @@
+// PROTOTYPE — Variant B "Command Dock". Horizontal bar pinned to the bottom.
+// Different hierarchy: stats inline left, segmented mode control as the hero,
+// regions/lines/layers behind popovers that open *upward* from the dock.
+import { useState } from 'react';
+import './VariantCommandDock.css';
+import { MODES, MODE_COLORS } from '../../services/modes';
+import { countByMode, filterLines } from './prototypeShared';
+
+export function VariantCommandDock(props) {
+  const {
+    vehicles = [], loading, onRefresh,
+    enabledModes = [], onModeToggle,
+    availableLines = {}, isLineSelected = () => false, onLineToggle = () => {},
+    selectedLines = [],
+    operators = [], activeOperators = [], onRegionSelect = () => {},
+    theme, onToggleTheme,
+    webcamsEnabled, onWebcamsToggle, webcamCount = 0,
+  } = props;
+
+  const [open, setOpen] = useState(null); // 'regions' | 'lines' | null
+  const [search, setSearch] = useState('');
+  const stats = countByMode(vehicles);
+  const lineOptions = filterLines(availableLines, search);
+  const toggle = (p) => setOpen(o => (o === p ? null : p));
+
+  return (
+    <div className="dock-root">
+      {open === 'regions' && (
+        <div className="dock-pop">
+          <div className="dock-pop-title">Regions</div>
+          <div className="dock-pop-chips">
+            <button className="dock-chip all" onClick={() => { onRegionSelect(null); setOpen(null); }}>All Sweden</button>
+            {operators.map(op => (
+              <button
+                key={op.slug}
+                className={`dock-chip ${activeOperators.includes(op.slug) ? 'active' : ''}`}
+                onClick={() => { onRegionSelect(op.slug); setOpen(null); }}
+                title={op.region}
+              >{op.name}</button>
+            ))}
+          </div>
+        </div>
+      )}
+      {open === 'lines' && (
+        <div className="dock-pop">
+          <div className="dock-pop-title">Filter by line</div>
+          <input className="dock-search" placeholder="Search lines…" value={search} onChange={e => setSearch(e.target.value)} />
+          <div className="dock-pop-chips scroll">
+            {Object.entries(lineOptions).flatMap(([mode, lines]) =>
+              lines.map(({ line }) => (
+                <button
+                  key={`${mode}:${line}`}
+                  className={`dock-chip ${isLineSelected(mode, line) ? 'active' : ''}`}
+                  style={{ '--accent': MODE_COLORS[mode] || '#888' }}
+                  onClick={() => onLineToggle(mode, line)}
+                >{line}</button>
+              )),
+            )}
+            {Object.keys(lineOptions).length === 0 && <span className="dock-empty">No matching lines</span>}
+          </div>
+        </div>
+      )}
+
+      <div className="dock">
+        <div className="dock-stats">
+          <div className="dock-stat"><b>{vehicles.length}</b><span>vehicles</span></div>
+          <div className="dock-stat"><b>{activeOperators.length}</b><span>operators</span></div>
+        </div>
+
+        <div className="dock-divider" />
+
+        <div className="dock-segment" role="group" aria-label="Transport modes">
+          {MODES.map(m => {
+            const on = enabledModes.includes(m.id);
+            return (
+              <button
+                key={m.id}
+                className={`dock-seg ${on ? 'on' : ''}`}
+                onClick={() => onModeToggle(m.id)}
+                style={on ? { background: m.color, borderColor: m.color, color: '#fff' } : {}}
+                title={`${m.label} (${stats[m.id] || 0})`}
+              >
+                {m.label}
+                <span className="dock-seg-count">{stats[m.id] || 0}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="dock-divider" />
+
+        <div className="dock-actions">
+          <button className={`dock-btn ${open === 'regions' ? 'open' : ''}`} onClick={() => toggle('regions')}>🌍 Regions</button>
+          <button className={`dock-btn ${open === 'lines' ? 'open' : ''}`} onClick={() => toggle('lines')}>
+            🚏 Lines{selectedLines.length > 0 && <span className="dock-badge">{selectedLines.length}</span>}
+          </button>
+          <button className={`dock-btn ${webcamsEnabled ? 'open' : ''}`} onClick={onWebcamsToggle}>
+            📷 Webcams{webcamsEnabled ? ` ${webcamCount}` : ''}
+          </button>
+          <button className="dock-btn icon" onClick={onRefresh} disabled={loading} title="Refresh">{loading ? '⟳' : '🔄'}</button>
+          <button className="dock-btn icon" onClick={onToggleTheme} title="Theme">{theme === 'dark' ? '☀' : '🌙'}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/prototype/VariantGlassHud.css
+++ b/src/components/prototype/VariantGlassHud.css
@@ -1,0 +1,93 @@
+/* PROTOTYPE — Variant A "Glass HUD". Frosted glass, neon accents. */
+.glass-hud {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  z-index: 1000;
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--chrome-bg) 70%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
+  backdrop-filter: blur(18px) saturate(160%);
+  border: 1px solid color-mix(in srgb, var(--chrome-text) 12%, transparent);
+  box-shadow: 0 12px 40px var(--chrome-shadow);
+  color: var(--chrome-text);
+  font-family: -apple-system, system-ui, sans-serif;
+}
+
+.glass-hud-top { display: flex; align-items: center; justify-content: space-between; }
+.glass-hud-title { display: flex; align-items: center; gap: 10px; }
+.glass-hud-title h2 { margin: 0; font-size: 16px; font-weight: 700; }
+.glass-hud-title small { color: var(--chrome-text-muted); font-size: 11px; }
+.glass-hud-pulse {
+  width: 10px; height: 10px; border-radius: 50%; background: #4ECDC4;
+  box-shadow: 0 0 0 0 #4ECDC4aa; animation: glassPulse 2s infinite;
+}
+@keyframes glassPulse {
+  0% { box-shadow: 0 0 0 0 #4ECDC4aa; }
+  70% { box-shadow: 0 0 0 8px #4ECDC400; }
+  100% { box-shadow: 0 0 0 0 #4ECDC400; }
+}
+.glass-hud-icon {
+  border: none; background: var(--chrome-hover-bg); border-radius: 10px;
+  width: 32px; height: 32px; cursor: pointer; font-size: 15px; color: var(--chrome-text);
+}
+
+.glass-hud-hero {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px; border-radius: 14px;
+  background: linear-gradient(135deg, color-mix(in srgb, #4ECDC4 22%, transparent), transparent);
+}
+.glass-hud-metric { display: flex; flex-direction: column; flex: 1; }
+.glass-hud-num { font-size: 30px; font-weight: 800; line-height: 1; letter-spacing: -1px; }
+.glass-hud-cap { font-size: 11px; color: var(--chrome-text-muted); text-transform: uppercase; letter-spacing: 1px; }
+.glass-hud-refresh {
+  width: 42px; height: 42px; border-radius: 50%; border: none; cursor: pointer;
+  background: #4ECDC4; color: #fff; font-size: 20px;
+}
+.glass-hud-refresh:disabled { opacity: .6; animation: spin 1s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.glass-hud-modes { display: flex; flex-wrap: wrap; gap: 6px; }
+.glass-hud-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 999px; cursor: pointer; font-size: 12px; font-weight: 600;
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  border: 1.5px solid var(--chrome-border); transition: all .18s;
+}
+.glass-hud-pill:not(.on) { opacity: .55; }
+.glass-hud-dot { width: 8px; height: 8px; border-radius: 50%; }
+.glass-hud-pill-count { font-size: 11px; opacity: .8; }
+
+.glass-hud-layer { display: flex; align-items: center; gap: 8px; font-size: 13px; cursor: pointer; }
+
+.glass-hud-regions { display: flex; flex-wrap: wrap; gap: 5px; }
+.glass-hud-region {
+  padding: 3px 10px; border-radius: 999px; font-size: 11px; cursor: pointer;
+  background: var(--chrome-chip-bg); color: var(--chrome-text);
+  border: 1.5px solid var(--chrome-border);
+}
+.glass-hud-region.all { border-color: #4ECDC4; color: #45b8af; font-weight: 700; }
+.glass-hud-region.active { border-color: #4ECDC4; background: var(--chrome-chip-selected-bg); font-weight: 600; }
+
+.glass-hud-lines { display: flex; flex-direction: column; gap: 8px; }
+.glass-hud-search {
+  width: 100%; box-sizing: border-box; padding: 9px 12px; border-radius: 10px;
+  border: 1px solid var(--chrome-border); background: var(--chrome-chip-bg); color: var(--chrome-text);
+  font-size: 13px; outline: none;
+}
+.glass-hud-search:focus { border-color: #4ECDC4; }
+.glass-hud-clear { background: none; border: none; color: var(--chrome-text-muted); font-size: 12px; cursor: pointer; text-align: left; }
+.glass-hud-line-scroll { max-height: 180px; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+.glass-hud-line-group { display: flex; flex-wrap: wrap; gap: 5px; }
+.glass-hud-chip {
+  padding: 3px 9px; border-radius: 8px; font-size: 12px; font-weight: 600; cursor: pointer;
+  background: var(--chrome-chip-bg); border: 1.5px solid var(--chrome-border); color: var(--chrome-text);
+}
+.glass-hud-chip.sel { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 18%, transparent); }
+.glass-hud-empty { color: var(--chrome-text-muted); font-size: 12px; padding: 6px 0; }
+.glass-hud-foot { font-size: 11px; color: var(--chrome-text-muted); text-align: center; }

--- a/src/components/prototype/VariantGlassHud.jsx
+++ b/src/components/prototype/VariantGlassHud.jsx
@@ -1,0 +1,123 @@
+// PROTOTYPE — Variant A "Glass HUD". Frosted vertical panel, hero stats,
+// glowing segmented mode pills. Structurally close to current but premium reskin.
+import { useState } from 'react';
+import './VariantGlassHud.css';
+import { MODES, MODE_COLORS, MODE_LABELS } from '../../services/modes';
+import { countByMode, filterLines } from './prototypeShared';
+
+export function VariantGlassHud(props) {
+  const {
+    vehicles = [], loading, lastUpdate, onRefresh,
+    enabledModes = [], onModeToggle,
+    availableLines = {}, isLineSelected = () => false, onLineToggle = () => {},
+    selectedLines = [], onClearLines = () => {},
+    operators = [], activeOperators = [], onRegionSelect = () => {},
+    effectiveInterval = 2000, theme, onToggleTheme,
+    webcamsEnabled, onWebcamsToggle, webcamCount = 0,
+  } = props;
+
+  const [search, setSearch] = useState('');
+  const stats = countByMode(vehicles);
+  const lineOptions = filterLines(availableLines, search);
+
+  return (
+    <div className="glass-hud">
+      <div className="glass-hud-top">
+        <div className="glass-hud-title">
+          <span className="glass-hud-pulse" />
+          <div>
+            <h2>Sweden Transit</h2>
+            <small>Live · every {effectiveInterval / 1000}s</small>
+          </div>
+        </div>
+        <button className="glass-hud-icon" onClick={onToggleTheme} aria-label="Toggle theme">
+          {theme === 'dark' ? '☀' : '🌙'}
+        </button>
+      </div>
+
+      <div className="glass-hud-hero">
+        <div className="glass-hud-metric">
+          <span className="glass-hud-num">{vehicles.length}</span>
+          <span className="glass-hud-cap">vehicles</span>
+        </div>
+        <div className="glass-hud-metric">
+          <span className="glass-hud-num">{activeOperators.length}</span>
+          <span className="glass-hud-cap">operators</span>
+        </div>
+        <button className="glass-hud-refresh" onClick={onRefresh} disabled={loading} title="Refresh now">
+          {loading ? '⟳' : '⟳'}
+        </button>
+      </div>
+
+      <div className="glass-hud-modes">
+        {MODES.map(m => {
+          const on = enabledModes.includes(m.id);
+          return (
+            <button
+              key={m.id}
+              className={`glass-hud-pill ${on ? 'on' : ''}`}
+              onClick={() => onModeToggle(m.id)}
+              style={on ? { '--accent': m.color, borderColor: m.color, boxShadow: `0 0 12px ${m.color}66` } : { '--accent': m.color }}
+            >
+              <span className="glass-hud-dot" style={{ background: m.color }} />
+              {m.label}
+              <span className="glass-hud-pill-count">{stats[m.id] || 0}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <label className="glass-hud-layer">
+        <input type="checkbox" checked={webcamsEnabled} onChange={onWebcamsToggle} />
+        <span>Webcams {webcamsEnabled ? `· ${webcamCount}` : ''}</span>
+      </label>
+
+      <div className="glass-hud-regions">
+        <button className="glass-hud-region all" onClick={() => onRegionSelect(null)}>All Sweden</button>
+        {operators.map(op => (
+          <button
+            key={op.slug}
+            className={`glass-hud-region ${activeOperators.includes(op.slug) ? 'active' : ''}`}
+            onClick={() => onRegionSelect(op.slug)}
+            title={op.region}
+          >
+            {op.name}
+          </button>
+        ))}
+      </div>
+
+      <div className="glass-hud-lines">
+        <input
+          className="glass-hud-search"
+          placeholder="🔍 Search lines…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        {selectedLines.length > 0 && (
+          <button className="glass-hud-clear" onClick={onClearLines}>Clear {selectedLines.length} selected</button>
+        )}
+        <div className="glass-hud-line-scroll">
+          {Object.entries(lineOptions).map(([mode, lines]) => (
+            <div key={mode} className="glass-hud-line-group">
+              {lines.map(({ line }) => (
+                <span
+                  key={`${mode}:${line}`}
+                  className={`glass-hud-chip ${isLineSelected(mode, line) ? 'sel' : ''}`}
+                  style={{ '--accent': MODE_COLORS[mode] || '#888' }}
+                  onClick={() => onLineToggle(mode, line)}
+                >
+                  {line}
+                </span>
+              ))}
+            </div>
+          ))}
+          {Object.keys(lineOptions).length === 0 && <div className="glass-hud-empty">No matching lines</div>}
+        </div>
+      </div>
+
+      {lastUpdate && (
+        <div className="glass-hud-foot">Updated {lastUpdate.toLocaleTimeString('sv-SE')}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/prototype/VariantIconRail.css
+++ b/src/components/prototype/VariantIconRail.css
@@ -1,0 +1,214 @@
+/* PROTOTYPE — Variant C "Icon Rail", Palantir-inspired.
+   Operational console aesthetic: hairline borders, sharp 2px corners, a steel-blue
+   accent, monospace readouts, uppercase micro-labels. Scoped palette below derives
+   from the app theme but pushes toward a denser, more neutral command-console look. */
+
+.rail-root {
+  /* light (rare for ops UIs, but kept usable) */
+  --pal-bg: #f7f8fa;
+  --pal-panel: #ffffff;
+  --pal-line: #d4d9e0;
+  --pal-line-soft: #e7eaef;
+  --pal-text: #1b2733;
+  --pal-muted: #5b6878;
+  --pal-faint: #8a96a6;
+  --pal-accent: #2f6fed;
+  --pal-accent-soft: rgba(47, 111, 237, 0.1);
+  --pal-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 1000;
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  font-family: -apple-system, system-ui, sans-serif;
+}
+
+[data-theme="dark"] .rail-root {
+  /* signature dark ops palette: near-black slate, steel-blue accent */
+  --pal-bg: #0b0e14;
+  --pal-panel: #11161f;
+  --pal-line: #232b38;
+  --pal-line-soft: #1a212c;
+  --pal-text: #c6d0dc;
+  --pal-muted: #7a8694;
+  --pal-faint: #545f6d;
+  --pal-accent: #4d9dff;
+  --pal-accent-soft: rgba(77, 157, 255, 0.12);
+}
+
+/* ── Rail ───────────────────────────────────────────────── */
+.rail {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  padding: 8px 6px;
+  border-radius: 2px;
+  background: var(--pal-panel);
+  border: 1px solid var(--pal-line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+}
+.rail-logo {
+  font-family: var(--pal-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: var(--pal-accent);
+  text-align: center;
+  padding: 4px 0 8px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--pal-line-soft);
+}
+.rail-spacer { flex: 1; min-height: 12px; }
+.rail-btn {
+  position: relative;
+  width: 38px; height: 38px;
+  border-radius: 2px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: transparent;
+  color: var(--pal-muted);
+  display: flex; align-items: center; justify-content: center;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.rail-btn:hover { background: var(--pal-accent-soft); color: var(--pal-text); }
+.rail-btn.active {
+  color: var(--pal-accent);
+  background: var(--pal-accent-soft);
+  border-color: color-mix(in srgb, var(--pal-accent) 45%, transparent);
+}
+.rail-btn:disabled { opacity: .5; cursor: default; }
+.rail-btn:focus-visible { outline: 2px solid var(--pal-accent); outline-offset: 1px; }
+.rail-glyph { font-size: 18px; line-height: 1; }
+.rail-glyph.spin { display: inline-block; animation: railspin 1s linear infinite; }
+@keyframes railspin { to { transform: rotate(360deg); } }
+.rail-dot {
+  position: absolute; top: 2px; right: 2px;
+  background: var(--pal-accent); color: #fff;
+  border-radius: 2px; font-family: var(--pal-mono);
+  font-size: 9px; min-width: 15px; height: 15px; padding: 0 3px;
+  display: flex; align-items: center; justify-content: center; font-weight: 700;
+}
+
+/* ── Flyout ─────────────────────────────────────────────── */
+.rail-flyout {
+  width: 286px;
+  border-radius: 2px;
+  background: var(--pal-panel);
+  border: 1px solid var(--pal-line);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+  color: var(--pal-text);
+  overflow: hidden;
+  animation: railIn .15s ease;
+}
+@keyframes railIn { from { opacity: 0; transform: translateX(-6px); } to { opacity: 1; transform: none; } }
+
+.rail-status {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 12px;
+  background: var(--pal-bg);
+  border-bottom: 1px solid var(--pal-line);
+  font-family: var(--pal-mono);
+  font-size: 10.5px;
+  letter-spacing: .5px;
+  color: var(--pal-muted);
+}
+.rail-led { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.rail-led.live { background: #2ec27e; box-shadow: 0 0 6px #2ec27e; animation: railpulse 2s infinite; }
+.rail-led.busy { background: var(--pal-accent); box-shadow: 0 0 6px var(--pal-accent); }
+@keyframes railpulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+.rail-status-text { color: var(--pal-text); font-weight: 600; }
+.rail-status-clock { margin-left: auto; color: var(--pal-faint); }
+
+.rail-flyout h3 {
+  margin: 0; padding: 12px 14px 10px;
+  font-family: var(--pal-mono);
+  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.2px;
+  color: var(--pal-faint);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.rail-clear {
+  background: none; border: 1px solid var(--pal-line); border-radius: 2px;
+  color: var(--pal-muted); font-family: var(--pal-mono); font-size: 10px; letter-spacing: .5px;
+  cursor: pointer; padding: 2px 6px;
+}
+.rail-clear:hover { border-color: var(--pal-accent); color: var(--pal-accent); }
+
+/* Overview readout */
+.rail-readout {
+  display: grid; grid-template-columns: 1fr 1fr;
+  border-top: 1px solid var(--pal-line-soft);
+  border-bottom: 1px solid var(--pal-line-soft);
+}
+.rail-readout-cell {
+  padding: 12px 14px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.rail-readout-cell + .rail-readout-cell { border-left: 1px solid var(--pal-line-soft); }
+.rail-readout-num {
+  font-family: var(--pal-mono); font-size: 30px; font-weight: 700;
+  line-height: 1; letter-spacing: -1px; color: var(--pal-text);
+}
+.rail-readout-cap {
+  font-size: 10px; text-transform: uppercase; letter-spacing: .8px; color: var(--pal-faint);
+}
+
+.rail-modebars { padding: 12px 14px; display: flex; flex-direction: column; gap: 9px; }
+.rail-bar { display: flex; align-items: center; gap: 9px; font-size: 11px; }
+.rail-bar-label { width: 48px; color: var(--pal-muted); text-transform: uppercase; letter-spacing: .4px; font-size: 10px; }
+.rail-bar-track { flex: 1; height: 4px; background: var(--pal-line-soft); overflow: hidden; }
+.rail-bar-fill { height: 100%; }
+.rail-bar-num { width: 30px; text-align: right; font-family: var(--pal-mono); font-weight: 600; color: var(--pal-text); }
+
+/* Mode / layer rows */
+.rail-modelist { padding: 6px; display: flex; flex-direction: column; }
+.rail-mode {
+  display: flex; align-items: center; gap: 10px; width: 100%;
+  padding: 9px 10px; border: none; border-radius: 2px; cursor: pointer;
+  background: transparent; color: var(--pal-text); font-size: 13px; text-align: left;
+  transition: background .12s;
+}
+.rail-mode:hover { background: var(--pal-accent-soft); }
+.rail-mode:not(.on) { opacity: .55; }
+.rail-swatch { width: 10px; height: 10px; flex-shrink: 0; }
+.rail-mode-name { flex: 1; font-weight: 600; }
+.rail-mode-count { font-family: var(--pal-mono); font-size: 11px; color: var(--pal-muted); }
+.rail-toggle {
+  width: 30px; height: 16px; border-radius: 2px; background: var(--pal-line);
+  position: relative; transition: background .15s; flex-shrink: 0;
+}
+.rail-toggle::after {
+  content: ''; position: absolute; top: 2px; left: 2px; width: 12px; height: 12px;
+  border-radius: 1px; background: var(--pal-faint); transition: transform .15s, background .15s;
+}
+.rail-toggle.on { background: var(--pal-accent-soft); }
+.rail-toggle.on::after { transform: translateX(14px); background: var(--pal-accent); }
+
+/* Chips */
+.rail-chips { display: flex; flex-wrap: wrap; gap: 5px; padding: 4px 14px 14px; }
+.rail-chips.scroll { max-height: 230px; overflow-y: auto; }
+.rail-chip {
+  padding: 4px 9px; border-radius: 2px; font-family: var(--pal-mono);
+  font-size: 11px; font-weight: 600; cursor: pointer; letter-spacing: .3px;
+  background: var(--pal-bg); border: 1px solid var(--pal-line); color: var(--pal-text);
+  transition: border-color .12s, background .12s;
+}
+.rail-chip:hover { border-color: var(--pal-muted); }
+.rail-chip.all { border-color: var(--pal-accent); color: var(--pal-accent); }
+.rail-chip.active {
+  border-color: var(--accent, var(--pal-accent));
+  background: color-mix(in srgb, var(--accent, var(--pal-accent)) 16%, transparent);
+  color: var(--pal-text);
+}
+.rail-search {
+  width: calc(100% - 28px); margin: 0 14px 10px; box-sizing: border-box;
+  padding: 8px 10px; border-radius: 2px; border: 1px solid var(--pal-line);
+  background: var(--pal-bg); color: var(--pal-text);
+  font-family: var(--pal-mono); font-size: 12px; letter-spacing: .5px; outline: none;
+}
+.rail-search::placeholder { color: var(--pal-faint); }
+.rail-search:focus { border-color: var(--pal-accent); }
+.rail-empty { color: var(--pal-faint); font-size: 12px; padding: 4px 0; }

--- a/src/components/prototype/VariantIconRail.jsx
+++ b/src/components/prototype/VariantIconRail.jsx
@@ -1,0 +1,171 @@
+// PROTOTYPE — Variant C "Icon Rail", Palantir-inspired operational reskin.
+// A thin vertical rail of icons; each opens a contextual flyout. Dense, technical,
+// monospace readouts, hairline borders, uppercase micro-labels — a command-console
+// feel rather than a friendly widget panel.
+import { useState } from 'react';
+import './VariantIconRail.css';
+import { MODES, MODE_COLORS } from '../../services/modes';
+import { countByMode, filterLines } from './prototypeShared';
+
+export function VariantIconRail(props) {
+  const {
+    vehicles = [], loading, lastUpdate, onRefresh,
+    enabledModes = [], onModeToggle,
+    availableLines = {}, isLineSelected = () => false, onLineToggle = () => {},
+    selectedLines = [], onClearLines = () => {},
+    operators = [], activeOperators = [], onRegionSelect = () => {},
+    effectiveInterval = 2000, theme, onToggleTheme,
+    webcamsEnabled, onWebcamsToggle, webcamCount = 0,
+  } = props;
+
+  const [panel, setPanel] = useState('stats'); // open by default so it's not empty
+  const [search, setSearch] = useState('');
+  const stats = countByMode(vehicles);
+  const lineOptions = filterLines(availableLines, search);
+  const sel = (p) => setPanel(cur => (cur === p ? null : p));
+
+  const RAIL = [
+    { id: 'stats', icon: '◧', label: 'Overview' },
+    { id: 'modes', icon: '◈', label: 'Modes' },
+    { id: 'regions', icon: '⬡', label: 'Regions' },
+    { id: 'lines', icon: '≣', label: 'Lines', badge: selectedLines.length },
+    { id: 'layers', icon: '⊞', label: 'Layers' },
+  ];
+
+  return (
+    <div className="rail-root">
+      <nav className="rail" aria-label="Control rail">
+        <div className="rail-logo" title="Sweden Real-Time Transit">STT</div>
+        {RAIL.map(item => (
+          <button
+            key={item.id}
+            className={`rail-btn ${panel === item.id ? 'active' : ''}`}
+            onClick={() => sel(item.id)}
+            title={item.label}
+            aria-label={item.label}
+            aria-pressed={panel === item.id}
+          >
+            <span className="rail-glyph">{item.icon}</span>
+            {item.badge > 0 && <span className="rail-dot">{item.badge}</span>}
+          </button>
+        ))}
+        <div className="rail-spacer" />
+        <button className="rail-btn" onClick={onRefresh} disabled={loading} title="Refresh feed">
+          <span className={`rail-glyph ${loading ? 'spin' : ''}`}>⟳</span>
+        </button>
+        <button className="rail-btn" onClick={onToggleTheme} title="Toggle theme" aria-label="Toggle theme">
+          <span className="rail-glyph">{theme === 'dark' ? '☀' : '☾'}</span>
+        </button>
+      </nav>
+
+      {panel && (
+        <section className="rail-flyout" aria-label={RAIL.find(r => r.id === panel)?.label}>
+          <div className="rail-status">
+            <span className={`rail-led ${loading ? 'busy' : 'live'}`} />
+            <span className="rail-status-text">
+              {loading ? 'SYNC' : 'LIVE'} · {(effectiveInterval / 1000).toFixed(1)}S · {activeOperators.length} OPR
+            </span>
+            <span className="rail-status-clock">{lastUpdate ? lastUpdate.toLocaleTimeString('sv-SE') : '—'}</span>
+          </div>
+
+          {panel === 'stats' && (
+            <>
+              <h3>Overview</h3>
+              <div className="rail-readout">
+                <div className="rail-readout-cell">
+                  <span className="rail-readout-num">{String(vehicles.length).padStart(3, '0')}</span>
+                  <span className="rail-readout-cap">Vehicles tracked</span>
+                </div>
+                <div className="rail-readout-cell">
+                  <span className="rail-readout-num">{String(activeOperators.length).padStart(2, '0')}</span>
+                  <span className="rail-readout-cap">Active operators</span>
+                </div>
+              </div>
+              <div className="rail-modebars">
+                {MODES.filter(m => stats[m.id]).map(m => {
+                  const pct = Math.round((stats[m.id] / Math.max(1, vehicles.length)) * 100);
+                  return (
+                    <div key={m.id} className="rail-bar">
+                      <span className="rail-bar-label">{m.label}</span>
+                      <div className="rail-bar-track"><div className="rail-bar-fill" style={{ width: `${pct}%`, background: m.color }} /></div>
+                      <span className="rail-bar-num">{String(stats[m.id]).padStart(3, ' ')}</span>
+                    </div>
+                  );
+                })}
+                {vehicles.length === 0 && <div className="rail-empty">No vehicles in viewport</div>}
+              </div>
+            </>
+          )}
+
+          {panel === 'modes' && (
+            <>
+              <h3>Transport modes</h3>
+              <div className="rail-modelist">
+                {MODES.map(m => {
+                  const on = enabledModes.includes(m.id);
+                  return (
+                    <button key={m.id} className={`rail-mode ${on ? 'on' : ''}`} onClick={() => onModeToggle(m.id)} aria-pressed={on}>
+                      <span className="rail-swatch" style={{ background: m.color }} />
+                      <span className="rail-mode-name">{m.label}</span>
+                      <span className="rail-mode-count">{String(stats[m.id] || 0).padStart(3, '0')}</span>
+                      <span className={`rail-toggle ${on ? 'on' : ''}`} />
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {panel === 'regions' && (
+            <>
+              <h3>Regions</h3>
+              <div className="rail-chips">
+                <button className="rail-chip all" onClick={() => onRegionSelect(null)}>ALL SWEDEN</button>
+                {operators.map(op => (
+                  <button
+                    key={op.slug}
+                    className={`rail-chip ${activeOperators.includes(op.slug) ? 'active' : ''}`}
+                    onClick={() => onRegionSelect(op.slug)}
+                    title={op.region}
+                  >{op.name}</button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {panel === 'lines' && (
+            <>
+              <h3>Filter · line{selectedLines.length > 0 && <button className="rail-clear" onClick={onClearLines}>CLR {selectedLines.length}</button>}</h3>
+              <input className="rail-search" placeholder="QUERY LINES…" value={search} onChange={e => setSearch(e.target.value)} />
+              <div className="rail-chips scroll">
+                {Object.entries(lineOptions).flatMap(([mode, lines]) =>
+                  lines.map(({ line }) => (
+                    <button
+                      key={`${mode}:${line}`}
+                      className={`rail-chip ${isLineSelected(mode, line) ? 'active' : ''}`}
+                      style={{ '--accent': MODE_COLORS[mode] || '#888' }}
+                      onClick={() => onLineToggle(mode, line)}
+                    >{line}</button>
+                  )),
+                )}
+                {Object.keys(lineOptions).length === 0 && <span className="rail-empty">No matching lines</span>}
+              </div>
+            </>
+          )}
+
+          {panel === 'layers' && (
+            <>
+              <h3>Layers</h3>
+              <button className={`rail-mode ${webcamsEnabled ? 'on' : ''}`} onClick={onWebcamsToggle} aria-pressed={webcamsEnabled}>
+                <span className="rail-swatch" style={{ background: '#2c3e50' }} />
+                <span className="rail-mode-name">Webcams</span>
+                <span className="rail-mode-count">{webcamsEnabled ? String(webcamCount).padStart(3, '0') : '—'}</span>
+                <span className={`rail-toggle ${webcamsEnabled ? 'on' : ''}`} />
+              </button>
+            </>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/prototype/prototypeShared.js
+++ b/src/components/prototype/prototypeShared.js
@@ -1,0 +1,27 @@
+// PROTOTYPE — throwaway. Shared helpers for the fancy ControlPanel variants.
+// Answers: "what should a fancier interface look like?" (sub-shape A, ?variant=).
+// Delete this whole prototype/ folder once a variant wins. See NOTES.md.
+import { MODE_LABELS } from '../../services/modes';
+
+/** Count vehicles per mode. */
+export function countByMode(vehicles = []) {
+  return vehicles.reduce((acc, v) => {
+    acc[v.mode] = (acc[v.mode] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+/** Filter the available-lines map by a free-text query (line number or mode name). */
+export function filterLines(availableLines = {}, query = '') {
+  const q = query.trim().toLowerCase();
+  if (!q) return availableLines;
+  const out = {};
+  for (const [mode, lines] of Object.entries(availableLines)) {
+    const modeLabel = (MODE_LABELS[mode] || mode).toLowerCase();
+    const matching = lines.filter(
+      ({ line }) => line.toLowerCase().includes(q) || modeLabel.includes(q),
+    );
+    if (matching.length > 0) out[mode] = matching;
+  }
+  return out;
+}

--- a/src/hooks/useGeolocation.js
+++ b/src/hooks/useGeolocation.js
@@ -1,0 +1,43 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+// All navigator.geolocation interaction lives behind this hook (the project's
+// "I/O behind a hook" rule). The position is ephemeral and client-only
+// (ADR 0005): held in React state only, never persisted, never sent anywhere.
+//
+// status is a discriminated enum: idle | locating | success | denied | unavailable.
+// This slice (issue #112) establishes idle → locating → success; denied/unavailable
+// are produced by the error path but their button UI lands in a later slice.
+
+// Standard accuracy (not GPS-grade) for a fast city-level fix; ~10s timeout;
+// a modest cache so a recent fix can return immediately.
+const GEO_OPTIONS = { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 };
+
+export function useGeolocation() {
+  const [status, setStatus] = useState('idle');
+  const [position, setPosition] = useState(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => () => { mountedRef.current = false; }, []);
+
+  const locate = useCallback(() => {
+    if (!navigator.geolocation) {
+      setStatus('unavailable');
+      return;
+    }
+    setStatus('locating');
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (!mountedRef.current) return;
+        setPosition({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+        setStatus('success');
+      },
+      (err) => {
+        if (!mountedRef.current) return;
+        setStatus(err && err.code === err.PERMISSION_DENIED ? 'denied' : 'unavailable');
+      },
+      GEO_OPTIONS,
+    );
+  }, []);
+
+  return { locate, position, status };
+}

--- a/src/hooks/useGeolocation.js
+++ b/src/hooks/useGeolocation.js
@@ -5,22 +5,31 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 // (ADR 0005): held in React state only, never persisted, never sent anywhere.
 //
 // status is a discriminated enum: idle | locating | success | denied | unavailable.
-// This slice (issue #112) establishes idle → locating → success; denied/unavailable
-// are produced by the error path but their button UI lands in a later slice.
+// Capability is evaluated up front (issue #113): if navigator.geolocation is
+// missing/blocked (insecure origin, no API support) the hook starts in
+// unavailable so the button is disabled before any tap. denied is the distinct
+// terminal state for a refused permission — refusal and absent capability are
+// never conflated (cf. the source-absence-vs-failure discipline).
+
+// Geolocation capability — absent API or insecure origin means the feature can
+// never produce a fix, distinct from a fix that was refused.
+function geolocationAvailable() {
+  return typeof navigator !== 'undefined' && !!navigator.geolocation;
+}
 
 // Standard accuracy (not GPS-grade) for a fast city-level fix; ~10s timeout;
 // a modest cache so a recent fix can return immediately.
 const GEO_OPTIONS = { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 };
 
 export function useGeolocation() {
-  const [status, setStatus] = useState('idle');
+  const [status, setStatus] = useState(() => (geolocationAvailable() ? 'idle' : 'unavailable'));
   const [position, setPosition] = useState(null);
   const mountedRef = useRef(true);
 
   useEffect(() => () => { mountedRef.current = false; }, []);
 
   const locate = useCallback(() => {
-    if (!navigator.geolocation) {
+    if (!geolocationAvailable()) {
       setStatus('unavailable');
       return;
     }

--- a/src/hooks/useGeolocation.test.js
+++ b/src/hooks/useGeolocation.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useGeolocation } from './useGeolocation';
+
+// Capture the success/error callbacks getCurrentPosition is invoked with so
+// tests can drive the async resolution deterministically (cf. useConnectivity).
+function installGeolocation() {
+  const calls = [];
+  const getCurrentPosition = vi.fn((onSuccess, onError, options) => {
+    calls.push({ onSuccess, onError, options });
+  });
+  navigator.geolocation = { getCurrentPosition };
+  return { calls, getCurrentPosition };
+}
+
+const malmoFix = {
+  coords: { latitude: 55.6050, longitude: 13.0038 },
+};
+
+describe('useGeolocation', () => {
+  let original;
+
+  beforeEach(() => {
+    original = navigator.geolocation;
+  });
+
+  afterEach(() => {
+    navigator.geolocation = original;
+    vi.restoreAllMocks();
+  });
+
+  it('starts idle with no position', () => {
+    installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    expect(result.current.status).toBe('idle');
+    expect(result.current.position).toBeNull();
+  });
+
+  it('reports locating while a fix is pending', () => {
+    installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    expect(result.current.status).toBe('locating');
+    expect(result.current.position).toBeNull();
+  });
+
+  it('yields success and the position when a fix arrives', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    act(() => { calls[0].onSuccess(malmoFix); });
+    expect(result.current.status).toBe('success');
+    expect(result.current.position).toEqual({ latitude: 55.6050, longitude: 13.0038 });
+  });
+
+  it('does not update state after unmount', () => {
+    const { calls } = installGeolocation();
+    const { result, unmount } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    unmount();
+    act(() => { calls[0].onSuccess(malmoFix); });
+    expect(result.current.status).toBe('locating');
+    expect(result.current.position).toBeNull();
+  });
+
+  it('requests a standard-accuracy fix with a ~10s timeout', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    expect(calls[0].options).toMatchObject({ enableHighAccuracy: false, timeout: 10000 });
+    expect(calls[0].options.maximumAge).toBeGreaterThan(0);
+  });
+
+  it('exposes exactly { locate, position, status }', () => {
+    installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    expect(Object.keys(result.current).sort()).toEqual(['locate', 'position', 'status']);
+    expect(typeof result.current.locate).toBe('function');
+  });
+});

--- a/src/hooks/useGeolocation.test.js
+++ b/src/hooks/useGeolocation.test.js
@@ -71,6 +71,28 @@ describe('useGeolocation', () => {
     expect(calls[0].options.maximumAge).toBeGreaterThan(0);
   });
 
+  it('evaluates capability on mount: a missing geolocation API yields unavailable', () => {
+    navigator.geolocation = undefined;
+    const { result } = renderHook(() => useGeolocation());
+    expect(result.current.status).toBe('unavailable');
+  });
+
+  it('resolves to denied when the user rejects the permission', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    act(() => { calls[0].onError({ code: 1, PERMISSION_DENIED: 1 }); });
+    expect(result.current.status).toBe('denied');
+  });
+
+  it('resolves to unavailable when the position is otherwise unobtainable', () => {
+    const { calls } = installGeolocation();
+    const { result } = renderHook(() => useGeolocation());
+    act(() => { result.current.locate(); });
+    act(() => { calls[0].onError({ code: 2, PERMISSION_DENIED: 1 }); });
+    expect(result.current.status).toBe('unavailable');
+  });
+
   it('exposes exactly { locate, position, status }', () => {
     installGeolocation();
     const { result } = renderHook(() => useGeolocation());


### PR DESCRIPTION
Second release to `main` (v1.0.0 → v1.1.0). Minor bump for the new geolocation feature.

**Since v1.0.0 (develop, 12 commits):**
- Geolocation "locate me" feature — PRD #111, slices #112–115 (#154). Fly-to + singleton User location marker, denied/unavailable states, in-progress feedback, accessible + theme-aware. ADR 0006.
- Palantir control-panel prototype — dev-only UI variants under `src/components/prototype/` (#155).
- Ponytail UI-wiring simplification (#156).
- Version bump 1.0.0 → 1.1.0.

Tag `v1.1.0` after merge; back-merge `main` → `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)