### PR TITLE
Back-merge main into develop (post-release 1.1.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "real-time-transit-tracker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "real-time-transit-tracker",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@vitejs/plugin-react": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "real-time-transit-tracker",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Sync develop with the v1.1.0 release — brings the package.json/lock version bump to 1.1.0. Git-flow back-merge, no feature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)