### PR TITLE
Add reinforcement loop: session capture → distill → reinforce

### DIFF
--- a/.agents/reinforcement-loop/DECISIONS.md
+++ b/.agents/reinforcement-loop/DECISIONS.md
@@ -1,0 +1,24 @@
+# Reinforcement decisions ledger (human view)
+
+The durable memory of the reinforcement loop. The **machine-readable source of
+truth is [`decisions.jsonl`](decisions.jsonl)** — `/distill` and `/reinforce`
+read that (one JSON object per line), not this table. `/reinforce` keeps this
+table in sync as the human-readable view. Edit `decisions.jsonl` if you need to
+change a ruling; re-render this table to match.
+
+`/reinforce` reads the ledger **first** so it never re-litigates or re-discovers
+a ruling. One entry per signature.
+
+- **promoted** — written into `AGENTS.md` (or `docs/`/a skill). Won't be re-added.
+- **rejected** — judged not worth encoding. Filtered out of future runs (so it can't resurface).
+- **watching** — seen once (`count < 2`). Not yet promoted; tracked until it recurs.
+
+`decisions.jsonl` row shape:
+
+```json
+{"sig":"skip-tests-before-pr","status":"promoted","count":2,"distinct_authors":2,"ruling":"Added to AGENTS.md Pre-PR gates","run":"2026-06-23"}
+```
+
+| sig | status | count | distinct authors | ruling / rationale | run |
+|-----|--------|-------|------------------|--------------------|-----|
+| _none yet_ | | | | | |

--- a/.agents/reinforcement-loop/README.md
+++ b/.agents/reinforcement-loop/README.md
@@ -1,0 +1,39 @@
+# Reinforcement loop
+
+Shared, checked-in memory that lets Claude Code learn from past sessions and
+feed those learnings back into `AGENTS.md` / skills — token-efficiently.
+
+## Pipeline (cheap+often → expensive+rare)
+
+| Stage | When | Cost | What |
+|-------|------|------|------|
+| **0 capture** | every session (`SessionEnd` hook) | 0 tokens | `.claude/reinforce-capture.{sh,mjs}` parse the transcript → a signal row + a filtered transcript cache, both **local** (`.local/`, gitignored). |
+| **1 distill** | manual `/distill` | Opus | reads local signals above threshold → headless Opus turns each into structured **learning candidates** (`candidates/<day>.jsonl`, shared/committed). |
+| **2 reinforce** | manual `/reinforce` | Opus, rare | groups candidates by `sig`, applies the promotion rule, refactors `AGENTS.md` via progressive disclosure, drafts skills, opens a PR. |
+
+**Invariant:** the raw transcript is read once, locally, and **filtered (~−90%)
+before any model sees it** — the model only ever reads the filtered transcript,
+never the raw one. Stage 2 reads only compact candidates, never transcripts.
+
+A `SessionStart` hook (`.claude/reinforce-daily.sh`) does a cheap, non-blocking
+daily check and reminds you to run `/distill` / `/reinforce` if they're due
+today — it never auto-runs them (slash-only, human-in-the-loop).
+
+## Promotion rule
+
+A learning is keyed by a canonical `sig`. Same `sig` seen **≥2 times → promoted**
+into `AGENTS.md`; **different authors → ranked higher**; seen once → `watching`.
+Idempotent via `sig` + [DECISIONS.md](DECISIONS.md).
+
+## Layout
+
+```
+candidates/YYYY-MM-DD.jsonl   shared, committed, append-only learning candidates
+DECISIONS.md                  the reinforcement memory: promoted | rejected | watching
+REINFORCE-LOG.md              one line per /reinforce run
+state.json                    { reinforced_through: "YYYY-MM-DD" } high-water-mark
+.local/                       gitignored, per-machine: signals/ + filtered cache + distilled_through
+```
+
+Skills: [/distill](../skills/distill/SKILL.md) · [/reinforce](../skills/reinforce/SKILL.md).
+Both are slash-only (never auto-invoked).

--- a/.agents/reinforcement-loop/REINFORCE-LOG.md
+++ b/.agents/reinforcement-loop/REINFORCE-LOG.md
@@ -1,0 +1,8 @@
+# Reinforce run log
+
+One line per `/reinforce` run: what was consolidated. Paired with `state.json`
+(`reinforced_through`) as the high-water-mark so runs stay incremental.
+
+| date | reinforced_through | promoted | watching | rejected | skills drafted | PR |
+|------|--------------------|----------|----------|----------|----------------|----|
+| _none yet_ | | | | | | |

--- a/.agents/reinforcement-loop/lib.mjs
+++ b/.agents/reinforcement-loop/lib.mjs
@@ -1,0 +1,47 @@
+// Shared helpers for the reinforcement loop (Stage 0 capture + /distill + /reinforce).
+// Co-located with the data these scripts operate on. Kept dependency-free.
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// Secrets we never want in a filtered cache or a committed candidate.
+export const SECRET_RE =
+  /(sk-(?:ant-)?[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|AKIA[0-9A-Z]{12,}|[\w.+-]+@[\w-]+\.[\w.-]+)/g;
+
+// Strip $HOME / absolute user paths, and (by default) secrets. Secret-stripping
+// is on by default so callers can't forget it.
+export function sanitize(s, { secrets = true } = {}) {
+  let out = String(s).replaceAll(homedir(), "~").replace(/\/Users\/[^/\s"']+/g, "~");
+  if (secrets) out = out.replace(SECRET_RE, "[redacted]");
+  return out;
+}
+
+// Parse a JSONL file → array of objects, skipping blank/garbage lines.
+export function readJsonl(file) {
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8").split("\n").filter(Boolean)
+    .flatMap((l) => { try { return [JSON.parse(l)]; } catch { return []; } });
+}
+
+// Concatenate every *.jsonl in a directory.
+export function loadJsonlDir(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((f) => f.endsWith(".jsonl")).flatMap((f) => readJsonl(join(dir, f)));
+}
+
+// decisions.jsonl is the machine-readable ledger (source of truth); DECISIONS.md
+// is the human view. Each row: { sig, status, count, distinct_authors, ruling, run }.
+const decisions = (rlDir) => readJsonl(join(rlDir, "decisions.jsonl"));
+
+// Sigs already promoted or rejected → never reconsidered (idempotency guarantee).
+export function ruledSigs(rlDir) {
+  return new Set(decisions(rlDir).filter((r) => r.status === "promoted" || r.status === "rejected").map((r) => r.sig));
+}
+
+// Every sig the ledger has seen (any status) — feeds the distill vocabulary.
+export function ledgerSigs(rlDir) {
+  return new Set(decisions(rlDir).map((r) => r.sig).filter(Boolean));
+}
+
+// A sig is valid iff it's kebab-case, 3–48 chars.
+export const isValidSig = (s) => /^[a-z0-9-]{3,48}$/.test(s || "");

--- a/.agents/reinforcement-loop/state.json
+++ b/.agents/reinforcement-loop/state.json
@@ -1,0 +1,3 @@
+{
+  "reinforced_through": "1970-01-01"
+}

--- a/.agents/skills/distill/SKILL.md
+++ b/.agents/skills/distill/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: distill
+description: Distill local Claude Code session signals into shared learning candidates for the reinforcement loop (Stage 1). Reads .agents/reinforcement-loop/.local signals captured by the SessionEnd hook and runs headless Haiku over the filtered transcripts to emit structured candidates. Use ONLY when the user explicitly runs /distill — never auto-invoke.
+disable-model-invocation: true
+argument-hint: "Optional: --dry to preview which sessions would be distilled"
+---
+
+# /distill — capture learnings from recent sessions (Stage 1)
+
+Turns the **local** signals written by the `SessionEnd` hook into **shared,
+committed** learning candidates. Part of the [reinforcement loop](../../reinforcement-loop/README.md).
+
+**Cost discipline:** the analysis runs on **Opus via a headless `claude -p`
+call inside the script** — do NOT read transcripts into your own context. The
+model only ever sees the **filtered** transcript (~−90% smaller), never the raw
+one. Your job is to run the script, sanity-check its output, and stage it for commit.
+
+## Run
+
+```bash
+node "$CLAUDE_PROJECT_DIR/.agents/skills/distill/scripts/distill.mjs" "$CLAUDE_PROJECT_DIR" $ARGUMENTS
+```
+
+- `$ARGUMENTS` may contain `--dry` → list the sessions that would be distilled, write nothing.
+- Selects unprocessed sessions with `score ≥ REINFORCE_MIN_SCORE` (default 1; loose by design — fires often).
+- Appends candidates to `.agents/reinforcement-loop/candidates/<day>.jsonl` and records processed sessions in `.local/distilled.json`.
+
+## What the script does (so you can trust it)
+
+1. Loads `.local/signals/*.jsonl`, drops already-processed sessions.
+2. Builds the existing `sig` vocabulary from `DECISIONS.md` + recent candidates,
+   so Haiku **reuses** keys → the same learning gets the same `sig` across sessions/users.
+3. For each session, pipes the **filtered** transcript + the prompt in
+   [reference/distill-prompt.md](reference/distill-prompt.md) to
+   `claude -p --bare --model opus` (override with `REINFORCE_DISTILL_MODEL`; child sets `CLAUDE_REINFORCE_CHILD=1`; `--bare` skips hooks → no recursion).
+4. Validates each emitted row, applies a secret/path **sanitization backstop**, enriches with author/session/day.
+
+## After running
+
+1. Review the new lines in `git diff .agents/reinforcement-loop/candidates/`.
+   Confirm: sensible `sig`s, no secrets/emails/absolute paths, summaries make sense.
+2. If a row looks wrong, edit or delete it (the file is plain JSONL).
+3. Stage the candidates + `.local/distilled.json` is gitignored — only `candidates/` gets committed:
+   ```bash
+   git add .agents/reinforcement-loop/candidates/
+   ```
+   Commit rides along with your next PR (or open a small one). **Never push to `main`/`develop`.**
+
+## Notes
+
+- Candidates are the **shared** unit; raw signals + filtered caches stay local (gitignored).
+- Promotion into `AGENTS.md` happens later in [/reinforce](../reinforce/SKILL.md), not here.
+- If `claude` CLI is missing, the script aborts without writing.

--- a/.agents/skills/distill/reference/distill-prompt.md
+++ b/.agents/skills/distill/reference/distill-prompt.md
@@ -1,0 +1,28 @@
+You are distilling ONE Claude Code coding session into reusable learning
+candidates for a team reinforcement loop. You are given a filtered transcript
+(user messages verbatim, assistant text, tool calls — thinking and large outputs
+removed) and the EXISTING SIGNATURE VOCABULARY already in use.
+
+Output **JSONL only** — one JSON object per line, no prose, no markdown fences.
+Emit a line ONLY for a genuine, reusable learning. If the session has nothing
+worth encoding, output nothing. Prefer 0–4 lines; never invent findings.
+
+Each line:
+{"sig":"kebab-case-key","type":"<type>","summary":"<≤140 chars>","evidence":"<≤160 chars, a short paraphrased quote — NO secrets, tokens, emails, or absolute paths>"}
+
+type ∈ missing-rule | friction | error-pattern | skill-candidate | went-well
+
+Rules for `sig` (this is what makes cross-session matching work):
+- **Reuse an existing sig verbatim** when the learning is the same idea, even if
+  worded differently ("forgot tests" and "didn't run npm test" → same sig).
+- Only mint a NEW kebab-case sig when no existing one fits. Keep it generic and durable.
+- The sig names the LEARNING, not the session specifics.
+
+What counts as a learning:
+- missing-rule: a convention the agent should have known (belongs in AGENTS.md).
+- error-pattern: a mistake the agent made and had to correct.
+- friction: repeated back-and-forth, redos, wrong assumptions.
+- skill-candidate: a multi-step command/workflow worth turning into a skill.
+- went-well: an approach that worked notably and should be reinforced.
+
+NEVER include secrets, API keys, tokens, passwords, emails, or absolute/home paths.

--- a/.agents/skills/distill/scripts/distill.mjs
+++ b/.agents/skills/distill/scripts/distill.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// /distill — Stage 1. Turn local session signals into shared learning candidates.
+//
+// Reads .local/signals/*.jsonl (Stage-0 output), selects unprocessed sessions
+// worth distilling, and for each runs headless Haiku over the FILTERED transcript
+// cache to emit structured candidates. The orchestrating agent must NOT read
+// transcripts itself — this script keeps the cheap-model invariant.
+//
+// Usage: node distill.mjs <repo-root> [--dry]
+//   env REINFORCE_MIN_SCORE (default 1), REINFORCE_DISTILL_MODEL (default "haiku"),
+//       REINFORCE_VOCAB_SIZE (default 50)
+import { readFileSync, writeFileSync, appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { loadJsonlDir, sanitize, ledgerSigs, isValidSig } from "../../../reinforcement-loop/lib.mjs";
+
+const root = process.argv[2] || process.cwd();
+const DRY = process.argv.includes("--dry");
+const MIN = Number(process.env.REINFORCE_MIN_SCORE || 1);
+const MODEL = process.env.REINFORCE_DISTILL_MODEL || "opus";
+const VOCAB_SIZE = Number(process.env.REINFORCE_VOCAB_SIZE || 50);
+const RL = join(root, ".agents", "reinforcement-loop");
+const LOCAL = join(RL, ".local");
+const PROMPT = readFileSync(join(root, ".agents", "skills", "distill", "reference", "distill-prompt.md"), "utf8");
+const TYPES = new Set(["missing-rule", "friction", "error-pattern", "skill-candidate", "went-well"]);
+
+// sig vocabulary = sigs in the ledger + recent candidates, so Haiku reuses keys.
+function sigVocab() {
+  const sigs = new Set(ledgerSigs(RL));
+  for (const c of loadJsonlDir(join(RL, "candidates"))) if (c.sig) sigs.add(c.sig);
+  return [...sigs].filter(Boolean).slice(-VOCAB_SIZE);
+}
+
+function distillSession(vocab, filteredPath) {
+  const input = `${PROMPT}\n\nEXISTING SIGNATURE VOCABULARY (reuse when applicable):\n${vocab.join(", ") || "(none yet)"}\n\nFILTERED TRANSCRIPT:\n${readFileSync(filteredPath, "utf8")}`;
+  const out = execFileSync("claude", ["-p", "--bare", "--model", MODEL], {
+    input, encoding: "utf8", maxBuffer: 8 * 1024 * 1024,
+    env: { ...process.env, CLAUDE_REINFORCE_CHILD: "1" },
+  });
+  return out.split("\n").map((l) => l.trim()).filter((l) => l.startsWith("{"))
+    .flatMap((l) => { try { return [JSON.parse(l)]; } catch { return []; } })
+    .filter((o) => o.sig && TYPES.has(o.type) && o.summary)
+    .map((o) => ({ sig: String(o.sig).toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 48), type: o.type, summary: sanitize(o.summary).slice(0, 140), evidence: sanitize(o.evidence || "").slice(0, 160) }))
+    .filter((o) => isValidSig(o.sig));
+}
+
+function main() {
+  const processedPath = join(LOCAL, "distilled.json");
+  const processed = new Set((existsSync(processedPath) ? JSON.parse(readFileSync(processedPath, "utf8")) : {}).sessions || []);
+  const todo = loadJsonlDir(join(LOCAL, "signals")).filter((s) => !processed.has(s.session) && s.score >= MIN);
+  if (!todo.length) { console.log("distill: nothing to do (no unprocessed sessions above threshold)"); return; }
+
+  if (!DRY) {
+    try { execFileSync("claude", ["--version"], { stdio: "ignore" }); }
+    catch { console.error("distill: `claude` CLI not found — aborting."); process.exit(1); }
+  }
+
+  const vocab = sigVocab();
+  let total = 0;
+  for (const s of todo) {
+    const cache = join(RL, s.cache);
+    if (!existsSync(cache)) { console.log(`distill: ${s.session} cache missing, skip`); processed.add(s.session); continue; }
+    console.log(`distill: ${s.session} (score ${s.score}, ${s.day})${DRY ? " [dry]" : ""}`);
+    if (DRY) { processed.add(s.session); continue; }
+    let rows = [];
+    try { rows = distillSession(vocab, cache); }
+    catch (e) { console.error(`distill: ${s.session} failed: ${e.message}`); continue; }
+    const enriched = rows.map((r) => ({ ...r, author: s.author, session: s.session, day: s.day, ts: s.ts }));
+    if (enriched.length) {
+      mkdirSync(join(RL, "candidates"), { recursive: true });
+      appendFileSync(join(RL, "candidates", `${s.day}.jsonl`), enriched.map((o) => JSON.stringify(o)).join("\n") + "\n");
+    }
+    total += enriched.length;
+    processed.add(s.session);
+  }
+  mkdirSync(LOCAL, { recursive: true });
+  writeFileSync(processedPath, JSON.stringify({ sessions: [...processed] }, null, 2) + "\n");
+  console.log(`distill: ${total} candidate(s) written across ${todo.length} session(s).`);
+}
+
+main();

--- a/.agents/skills/reinforce/SKILL.md
+++ b/.agents/skills/reinforce/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: reinforce
+description: Consolidate the reinforcement loop's shared learning candidates into AGENTS.md, docs/, and new skills, then open a PR (Stage 2). Groups candidates by signature, promotes anything seen twice (cross-user ranks higher), and refactors AGENTS.md via a progressive-disclosure prompt. Use ONLY when the user explicitly runs /reinforce — never auto-invoke.
+disable-model-invocation: true
+argument-hint: "Optional: a focus area, e.g. 'only testing rules'"
+---
+
+# /reinforce — fold learnings into AGENTS.md + skills (Stage 2)
+
+Consolidates the **shared** candidates produced by [/distill](../distill/SKILL.md)
+into durable project guidance. Part of the [reinforcement loop](../../reinforcement-loop/README.md).
+Runs rarely, on the strong model, but only ever reads **compact candidates —
+never raw transcripts**.
+
+## 1. Tally (deterministic)
+
+```bash
+node "$CLAUDE_PROJECT_DIR/.agents/skills/reinforce/scripts/tally.mjs" "$CLAUDE_PROJECT_DIR"
+```
+
+Prints `{ promoted, watching, skipped, totals }`. The **promotion rule** and the
+ledger format live in [reference/promotion.md](reference/promotion.md):
+seen ≥2 → promote, different authors → higher priority, seen once → watching,
+already-ruled → skipped. If `promoted` is empty, report that and stop (nothing to do).
+
+## 2. Encode the promoted learnings
+
+Apply the **progressive-disclosure refactor** to `AGENTS.md`, feeding the promoted
+learnings in as candidate rules/links. Follow [reference/progressive-disclosure.md](reference/progressive-disclosure.md)
+**verbatim** (the 6-step prompt). Key points:
+
+- Route each learning to the right altitude: root only if relevant to *every*
+  task, else a `docs/<category>.md` or a skill, linked from the root map.
+- Step 1 contradictions → **AskUserQuestion**; record the losing side as `rejected`.
+- `type: skill-candidate` → draft a new skill via the `write-a-skill` skill.
+- `CLAUDE.md` is a symlink to `AGENTS.md` — edit `AGENTS.md` only.
+- If `$ARGUMENTS` names a focus area, limit this pass to matching sigs.
+
+## 3. Record + ship
+
+1. Append one JSON row per sig you acted on (promoted / rejected / watching) to
+   `.agents/reinforcement-loop/decisions.jsonl` — the machine-readable ledger that
+   stops the loop from re-discovering or re-litigating next run — then mirror the
+   same rows into the `DECISIONS.md` table (human view). Format: [reference/promotion.md](reference/promotion.md).
+2. Add a line to `REINFORCE-LOG.md`; set `state.json.reinforced_through` to `date +%F`.
+3. Show the full diff to the user, then open a PR into `develop` via the
+   [create-pr](../create-pr/SKILL.md) skill (it runs the pre-PR gates). **Never push to `main`/`develop`.**
+
+## Guarantees
+
+- **Idempotent**: `DECISIONS.md` ensures each sig is encoded at most once; re-runs are safe.
+- **Bounded**: tally reads only structured candidate rows; the strong model never ingests transcripts.
+- **Auditable**: every change lands in a PR with the ledger explaining why.

--- a/.agents/skills/reinforce/reference/progressive-disclosure.md
+++ b/.agents/skills/reinforce/reference/progressive-disclosure.md
@@ -1,0 +1,26 @@
+# AGENTS.md refactor prompt (apply verbatim)
+
+When `/reinforce` updates `AGENTS.md`, apply this exact prompt. The promoted
+learnings (from the tally) are fed in as **candidate root rules / links** that
+are subject to this same pass — so reinforcement routes each learning to the
+right altitude (root vs `docs/` vs a skill) instead of bloating the root.
+
+> Refactor my AGENTS.md to follow progressive disclosure.
+> docs/
+> 1. Find contradictions. Ask which to keep.
+> 2. Extract essentials for the root: one-line description, package manager, build / typecheck, anything truly relevant to every task.
+> 3. Keep the 2–3 most critical workflows in the root as numbered steps — they earn their place.
+> 4. Group the rest into categories. One markdown file per category in docs/. Move procedural know-how into .agents/skills/<name>/SKILL.md.
+> 5. Output a minimal root AGENTS.md linking each file with a one-line description. Replace code snippets with file:line refs.
+> 6. Flag for deletion: redundant, vague, or overly obvious instructions.
+
+## Applying it with reinforcement input
+
+- Step 1 (contradictions): use **AskUserQuestion** when a promoted learning
+  conflicts with an existing rule — ask which to keep; record the loser as
+  `rejected` in `DECISIONS.md`.
+- A promoted learning earns a **root** line only if it's relevant to *every*
+  task (step 2/3). Otherwise route it to the right `docs/<category>.md` or a
+  skill, and link it from the root map.
+- `CLAUDE.md` is a **symlink** to `AGENTS.md` — edit `AGENTS.md` only; the mirror updates itself.
+- Keep the root scannable: prefer a one-line link over inlined prose; use `file:line` refs over code snippets.

--- a/.agents/skills/reinforce/reference/promotion.md
+++ b/.agents/skills/reinforce/reference/promotion.md
@@ -1,0 +1,41 @@
+# Promotion rule & ledger format
+
+## Rule (implemented in scripts/tally.mjs)
+
+Candidates are grouped by `sig` across the **full** committed history.
+
+- `count ≥ 2` → **promote** (encode into `AGENTS.md` / `docs/` / a skill).
+- `distinct_authors ≥ 2` → **higher priority** (`cross_user: true`) — process first.
+- `count == 1` → **watching** (record, do not touch `AGENTS.md`).
+- sig already `promoted`/`rejected` in `DECISIONS.md` → **skipped** (no re-litigation).
+
+Re-running is idempotent: the ledger, not a high-water-mark, guarantees a sig is
+encoded at most once. `state.json.reinforced_through` is an informational marker only.
+
+## The ledger — `decisions.jsonl` is the source of truth
+
+`tally.mjs` reads `decisions.jsonl` (machine-readable) to decide what's already
+ruled. After acting, **append one JSON row per sig** you touched:
+
+```json
+{"sig":"<sig>","status":"promoted|rejected|watching","count":<n>,"distinct_authors":<n>,"ruling":"<why + where it landed>","run":"<YYYY-MM-DD>"}
+```
+
+- **promoted**: rule/skill you added + where it landed (root / `docs/x.md` / skill name).
+- **rejected**: why it's not worth encoding, or which side of a contradiction lost.
+- **watching**: record the tally's watching sigs so the next run sees their prior count.
+
+Then mirror the same rows into the `DECISIONS.md` table (the human view) so the
+two stay in sync.
+
+## skill-candidate sigs
+
+If a promoted sig has `type` including `skill-candidate`, draft a new skill via
+the `write-a-skill` skill (frontmatter, ≤150-line SKILL.md, progressive disclosure).
+Record it as `promoted` with the skill name in the ruling.
+
+## After encoding
+
+1. Update `DECISIONS.md` (rows above) and `REINFORCE-LOG.md` (one summary line).
+2. Set `state.json.reinforced_through` to today (`date +%F`).
+3. Open a PR into `develop` via the `create-pr` skill. Never push to `main`/`develop`.

--- a/.agents/skills/reinforce/scripts/tally.mjs
+++ b/.agents/skills/reinforce/scripts/tally.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// /reinforce — Stage 2 tally. Group shared candidates by `sig`, apply the
+// promotion rule, and emit the work list. Deterministic; prints JSON to stdout.
+//
+// Promotion rule: count ≥2 → promote; distinct authors ≥2 → higher priority;
+// count 1 → watching. Sigs already ruled in decisions.jsonl are skipped.
+//
+// Reads the FULL candidate history (rows are tiny) so counts are accurate even
+// when an earlier "watching" sig recurs in a later batch. The ledger
+// (decisions.jsonl) prevents re-promotion, so re-runs are idempotent.
+//
+// Usage: node tally.mjs <repo-root>
+import { join } from "node:path";
+import { loadJsonlDir, ruledSigs } from "../../../reinforcement-loop/lib.mjs";
+
+const root = process.argv[2] || process.cwd();
+const RL = join(root, ".agents", "reinforcement-loop");
+
+const groups = new Map();
+for (const c of loadJsonlDir(join(RL, "candidates"))) {
+  if (!c.sig) continue;
+  const g = groups.get(c.sig) || { sig: c.sig, count: 0, authors: new Set(), types: new Set(), summaries: [] };
+  g.count++; g.authors.add(c.author || "unknown"); g.types.add(c.type);
+  if (g.summaries.length < 3 && c.summary) g.summaries.push(c.summary);
+  groups.set(c.sig, g);
+}
+
+const done = ruledSigs(RL);
+const promoted = [], watching = [], skipped = [];
+for (const g of groups.values()) {
+  const rec = { sig: g.sig, count: g.count, distinct_authors: g.authors.size, types: [...g.types], summaries: g.summaries, cross_user: g.authors.size >= 2 };
+  if (done.has(g.sig)) skipped.push(rec);
+  else if (g.count >= 2) promoted.push(rec);
+  else watching.push(rec);
+}
+// cross-user first, then by count.
+promoted.sort((a, b) => Number(b.cross_user) - Number(a.cross_user) || b.count - a.count);
+
+console.log(JSON.stringify({
+  promoted, watching, skipped,
+  totals: { sigs: groups.size, promoted: promoted.length, watching: watching.length, skipped: skipped.length },
+}, null, 2));

--- a/.claude/reinforce-capture.mjs
+++ b/.claude/reinforce-capture.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Reinforcement loop — Stage 0 parser (invoked by reinforce-capture.sh).
+//
+// Input : SessionEnd hook JSON on stdin ({ transcript_path, session_id, cwd, ... }).
+// Output: appends one signal row to .local/signals/<day>.jsonl and writes a
+//         filtered transcript to .local/cache/<session>.filtered.jsonl.
+// Contract: deterministic, zero tokens, never throws to the caller (best-effort).
+//
+// The correction-marker regex / redo-count / score here are a cheap RECALL
+// prefilter for "which sessions are worth distilling" — the actual judgment is
+// deferred to Haiku in /distill. They don't need to be precise.
+import { readFileSync, mkdirSync, appendFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { readJsonl, sanitize } from "../.agents/reinforcement-loop/lib.mjs";
+
+const root = process.argv[2] || process.cwd();
+const LOCAL = join(root, ".agents", "reinforcement-loop", ".local");
+const cap = (s, n) => sanitize(s).slice(0, n);
+
+const CORRECTION_RE =
+  /\b(nej|inte s[åa]|i ?st[äa]llet|fel(?:aktig)?|backa|[åa]ngra|no,|not (?:that|what)|wrong|revert|undo|don'?t do)\b/i;
+
+function readStdin() {
+  try { return JSON.parse(readFileSync(0, "utf8")); } catch { return {}; }
+}
+
+function textOf(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.filter((b) => b?.type === "text").map((b) => b.text || "").join("\n");
+}
+
+function main() {
+  const { transcript_path, session_id = "unknown", cwd } = readStdin();
+  if (!transcript_path) return;
+  const events = readJsonl(transcript_path);
+  if (!events.length) return;
+
+  let turns = 0, userMsgs = 0, toolErrors = 0, corrections = 0;
+  const filesTouched = new Set();
+  const editCount = new Map();
+  const commands = new Set();
+  const filtered = [];
+  let branch = "", ts = "";
+
+  for (const e of events) {
+    if (e.gitBranch) branch = e.gitBranch;
+    if (e.timestamp) ts = e.timestamp;
+    const msg = e.message;
+    if (!msg) continue;
+
+    if (e.type === "assistant") {
+      turns++;
+      for (const b of msg.content || []) {
+        if (b.type === "text") filtered.push({ role: "assistant", type: "text", text: cap(b.text, 2000) });
+        else if (b.type === "tool_use") {
+          const name = b.name || "tool";
+          const inp = b.input || {};
+          const fp = inp.file_path || inp.path;
+          if (fp && /^(Edit|Write|MultiEdit|NotebookEdit)$/.test(name)) {
+            filesTouched.add(sanitize(fp));
+            editCount.set(fp, (editCount.get(fp) || 0) + 1);
+          }
+          if (name === "Bash" && inp.command) commands.add(cap(inp.command, 60));
+          filtered.push({ role: "assistant", type: "tool_use", name, target: sanitize(fp || ""), cmd: name === "Bash" ? cap(inp.command || "", 120) : "" });
+        }
+      }
+    } else if (e.type === "user") {
+      if (e.isMeta) continue;
+      const content = msg.content;
+      // tool_result blocks come back as user-role; count errors, don't treat as prompts.
+      if (Array.isArray(content) && content.some((b) => b?.type === "tool_result")) {
+        for (const b of content) if (b?.type === "tool_result" && b.is_error) toolErrors++;
+        continue;
+      }
+      const t = textOf(content).trim();
+      if (!t) continue;
+      userMsgs++;
+      if (CORRECTION_RE.test(t)) corrections++;
+      filtered.push({ role: "user", type: "text", text: cap(t, 2000) });
+    }
+  }
+
+  let redoCount = 0;
+  for (const n of editCount.values()) redoCount += n > 1 ? n - 1 : 0;
+
+  let author = "unknown";
+  try { author = execSync("git config user.name", { cwd: cwd || root }).toString().trim() || "unknown"; } catch { /* noop */ }
+
+  const day = (ts || new Date().toISOString()).slice(0, 10);
+  const short = String(session_id).slice(0, 8);
+  const score = (turns >= 4 ? 1 : 0) + toolErrors + corrections + redoCount;
+
+  mkdirSync(join(LOCAL, "signals"), { recursive: true });
+  mkdirSync(join(LOCAL, "cache"), { recursive: true });
+  writeFileSync(join(LOCAL, "cache", `${short}.filtered.jsonl`), filtered.map((o) => JSON.stringify(o)).join("\n") + "\n");
+
+  const row = {
+    session: short, day, ts: ts || "", branch, author,
+    turns, user_msgs: userMsgs, files_touched: [...filesTouched],
+    commands: [...commands], tool_errors: toolErrors,
+    correction_markers: corrections, redo_count: redoCount,
+    cache: join(".local", "cache", `${short}.filtered.jsonl`), score,
+  };
+  appendFileSync(join(LOCAL, "signals", `${day}.jsonl`), JSON.stringify(row) + "\n");
+}
+
+try { main(); } catch { /* best-effort: never break session shutdown */ }

--- a/.claude/reinforce-capture.sh
+++ b/.claude/reinforce-capture.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Reinforcement loop — Stage 0 capture (SessionEnd hook).
+# Deterministic, zero-token: parses the session transcript into a compact signal
+# row + a filtered local transcript cache. All heavy/LLM work happens later in
+# the /distill skill. Must never break session shutdown → always exits 0.
+#
+# Reads the SessionEnd hook JSON (with transcript_path) on stdin and forwards it
+# to the Node parser. See .claude/reinforce-capture.mjs.
+set -euo pipefail
+
+# Recursion guard: a headless `claude -p --bare` child already skips hooks, but
+# this is belt-and-suspenders in case --bare is ever dropped.
+[ "${CLAUDE_REINFORCE_CHILD:-}" = "1" ] && exit 0
+
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+parser="$root/.claude/reinforce-capture.mjs"
+
+[ -f "$parser" ] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
+
+# Never let a parser failure surface as a hook error.
+node "$parser" "$root" || true
+exit 0

--- a/.claude/reinforce-daily.mjs
+++ b/.claude/reinforce-daily.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Reinforcement loop — daily check (invoked by reinforce-daily.sh on SessionStart).
+//
+// CHEAP and NON-BLOCKING: no LLM, just reads small JSON/JSONL files. Decides
+// whether /distill or /reinforce is "due" today and, if so, prints a short
+// context line so the agent proactively offers to run them — WITHOUT auto-running
+// (the user chose the human-in-the-loop variant). Never throws; exits 0.
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { loadJsonlDir, ruledSigs } from "../.agents/reinforcement-loop/lib.mjs";
+
+const root = process.argv[2] || process.cwd();
+const MIN = Number(process.env.REINFORCE_MIN_SCORE || 1);
+const RL = join(root, ".agents", "reinforcement-loop");
+const LOCAL = join(RL, ".local");
+const today = new Date().toISOString().slice(0, 10);
+const readJson = (p, d) => { try { return JSON.parse(readFileSync(p, "utf8")); } catch { return d; } };
+
+function main() {
+  // distill due: unprocessed local sessions above the threshold.
+  const processed = new Set(readJson(join(LOCAL, "distilled.json"), {}).sessions || []);
+  const distillDue = loadJsonlDir(join(LOCAL, "signals")).filter((s) => !processed.has(s.session) && s.score >= MIN).length;
+
+  // reinforce due: unruled candidate signatures exist AND it hasn't run today.
+  const sigs = new Set(loadJsonlDir(join(RL, "candidates")).map((c) => c.sig).filter(Boolean));
+  const ruled = ruledSigs(RL);
+  const unruled = [...sigs].filter((s) => !ruled.has(s)).length;
+  const ranToday = readJson(join(RL, "state.json"), {}).reinforced_through === today;
+  const reinforceDue = unruled > 0 && !ranToday;
+
+  if (!distillDue && !reinforceDue) return; // nothing due → stay quiet.
+
+  const lines = ["⟳ Reinforcement loop — daily check:"];
+  if (distillDue) lines.push(`- /distill: ${distillDue} local session(s) ready to distill into candidates.`);
+  if (reinforceDue) lines.push(`- /reinforce: due — ${unruled} unruled candidate signature(s), not yet run today.`);
+  lines.push("Proactively offer to run the due step(s) for the user (slash-only — do not auto-run).");
+  console.log(lines.join("\n"));
+}
+
+try { main(); } catch { /* best-effort: never disrupt session start */ }

--- a/.claude/reinforce-daily.sh
+++ b/.claude/reinforce-daily.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Reinforcement loop — daily check (SessionStart hook). Cheap, non-blocking:
+# prints a short reminder to stdout (added to session context) if /distill or
+# /reinforce is due today. Does NOT run them — the user runs the slash command.
+set -euo pipefail
+
+# Don't fire inside a headless reinforcement child.
+[ "${CLAUDE_REINFORCE_CHILD:-}" = "1" ] && exit 0
+
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+checker="$root/.claude/reinforce-daily.mjs"
+
+[ -f "$checker" ] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
+
+node "$checker" "$root" || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,22 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/sync-skills.sh\"",
             "statusMessage": "Syncing project skills (.agents/skills → .claude/skills)"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/reinforce-daily.sh\"",
+            "statusMessage": "Reinforcement loop: daily distill/reinforce check"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/reinforce-capture.sh\"",
+            "statusMessage": "Capturing session signals (reinforcement loop)"
           }
         ]
       }

--- a/.claude/skills/distill
+++ b/.claude/skills/distill
@@ -1,0 +1,1 @@
+../../.agents/skills/distill

--- a/.claude/skills/reinforce
+++ b/.claude/skills/reinforce
@@ -1,0 +1,1 @@
+../../.agents/skills/reinforce

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .claude/worktrees/
 .aspire/
 .claude/settings.local.json
+.agents/reinforcement-loop/.local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Real-time Leaflet map of Swedish public-transport vehicles, polled ~2s from Traf
 | [docs/agents/domain.md](docs/agents/domain.md) | how agents consume CONTEXT.md + ADRs |
 | [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md) | GitHub issue conventions via `gh` |
 | [docs/agents/triage-labels.md](docs/agents/triage-labels.md) | triage label vocabulary |
+| [docs/agents/reinforcement-loop.md](docs/agents/reinforcement-loop.md) | how sessions are distilled into AGENTS.md/skill improvements (`/distill`, `/reinforce`) |
 | [research/](research/) | 8-part design docs (APIs, GTFS-RT, stack, multi-operator) |
 
 ### Skills — `.agents/skills/<name>/SKILL.md`
@@ -54,6 +55,7 @@ Real-time Leaflet map of Swedish public-transport vehicles, polled ~2s from Traf
 - [refresh-trip-mapping](.agents/skills/refresh-trip-mapping/SKILL.md) — rebuild the GTFS static trip mapping
 - [create-pr](.agents/skills/create-pr/SKILL.md) — open a PR (asks base branch) with pre-PR gates
 - [observe-running-app](.agents/skills/observe-running-app/SKILL.md) — see the running SPA's browser console/network via Aspire
+- [distill](.agents/skills/distill/SKILL.md) / [reinforce](.agents/skills/reinforce/SKILL.md) — reinforcement loop: turn past sessions into AGENTS.md/skill improvements (slash-only)
 
 Plus a general library in the same dir: engineering workflow (`tdd`, `diagnose`, `improve-codebase-architecture`, `prototype`, `handoff`), planning/issues (`to-prd`, `to-issues`, `triage`, `grill-me`, `grill-with-docs`), Aspire (`aspire`, `aspire-monitoring`, `aspire-orchestration`, `aspire-deployment`, `aspireify`, `aspire-init`), and authoring (`write-a-skill`, `teach`, `zoom-out`). Browse `.agents/skills/` for the full set.
 

--- a/docs/agents/reinforcement-loop.md
+++ b/docs/agents/reinforcement-loop.md
@@ -1,0 +1,48 @@
+# Reinforcement loop
+
+How Claude Code learns from past sessions and feeds the learnings back into
+`AGENTS.md` and skills — token-efficiently, as shared team memory checked into
+the repo. Grounded in Anthropic's guidance on self-improving agents (Agent
+Skills, "Writing tools for agents", context engineering).
+
+## Three stages — cheap+often → expensive+rare
+
+| Stage | Trigger | Model | Reads | Writes |
+|-------|---------|-------|-------|--------|
+| 0 capture | `SessionEnd` hook (auto) | none | session transcript | local signal row + filtered cache (`.local/`, gitignored) |
+| 1 distill | `/distill` (manual) | Opus | local signals + filtered cache | shared `candidates/<day>.jsonl` |
+| 2 reinforce | `/reinforce` (manual) | Opus | shared candidates | `AGENTS.md` / `docs/` / skills via PR |
+
+A `SessionStart` hook does a cheap, non-blocking daily check and reminds you to
+run `/distill` / `/reinforce` when they're due today — it never auto-runs them.
+
+**Invariant:** the raw transcript is read exactly once, locally, and **filtered
+(~−90%) before any model sees it** — the model reads only the filtered transcript,
+never the raw one. Stage 2 reads only compact candidates, never transcripts.
+
+## Why this split saves tokens
+
+- Most sessions cost **0 tokens** (Stage 0 is pure Node/bash).
+- Stage 1 filters transcripts (~−90%) before the model, gates on a signal score, and batches.
+- Stage 2 reads only structured rows, so its cost scales with *learnings*, not transcript size.
+
+## The signature mechanism (how it "gets better")
+
+Each learning is keyed by a canonical `sig`. `/distill` is fed the existing sig
+vocabulary so it **reuses** keys → cross-session/cross-user matching is a key
+match, not fuzzy NLP. `/reinforce` then promotes any `sig` seen **≥2 times**
+into `AGENTS.md`; **different authors rank higher**; seen once stays `watching`.
+
+## Files
+
+- Hooks: `.claude/reinforce-capture.{sh,mjs}` (Stage 0, `SessionEnd`); `.claude/reinforce-daily.{sh,mjs}` (daily reminder, `SessionStart`).
+- Skills: `.agents/skills/distill/`, `.agents/skills/reinforce/` (slash-only).
+- Data: `.agents/reinforcement-loop/` — `candidates/` (shared), `DECISIONS.md`
+  (the memory: promoted/rejected/watching), `REINFORCE-LOG.md`, `state.json`;
+  `.local/` is per-machine and gitignored. See its [README](../../.agents/reinforcement-loop/README.md).
+
+## Privacy
+
+Signals and filtered caches stay local. Only sanitized candidates are committed;
+both Stage 0 and Stage 1 strip secrets, tokens, emails, and absolute/home paths.
+Consistent with the cookieless, no-PII posture (ADR 0001).


### PR DESCRIPTION
## Summary

A three-stage **reinforcement loop** that learns from past Claude Code sessions and feeds the learnings back into `AGENTS.md` / skills — token-efficiently, as **shared team memory checked into the repo**. Grounded in Anthropic's guidance on self-improving agents.

| Stage | Trigger | Model | Cost |
|-------|---------|-------|------|
| **0 capture** | `SessionEnd` hook (auto) | none | 0 tokens — parses transcript → signal row + filtered (~−90%) local cache (`.local/`, gitignored) |
| **1 distill** | `/distill` (slash-only) | Opus | headless `claude -p` over the **filtered** cache → structured learning candidates keyed by a canonical `sig` (shared/committed) |
| **2 reinforce** | `/reinforce` (slash-only) | Opus | groups candidates by `sig`, promotes any seen **≥2×** (cross-user ranks higher), refactors `AGENTS.md` via the progressive-disclosure prompt, drafts skills, opens a PR |

**Invariant:** the raw transcript is read once, locally, and filtered before any model sees it — the model never reads raw transcripts.

**Promotion mechanism:** learnings are keyed by a canonical `sig`; `/distill` reuses the existing vocabulary so cross-session/cross-user matching is a key-match. `decisions.jsonl` is the machine-readable idempotency ledger (DECISIONS.md is the human view), so re-runs never re-promote.

**SessionStart daily check** (`.claude/reinforce-daily.{sh,mjs}`): cheap, non-blocking reminder to run `/distill` / `/reinforce` when due today — never auto-runs (human-in-the-loop kept for contradiction questions + PR approval).

Both skills are `disable-model-invocation: true` (slash-only). `CLAUDE.md` already symlinks `AGENTS.md`, so the mirror updates itself.

## Files
- Hooks: `.claude/reinforce-capture.{sh,mjs}` (Stage 0), `.claude/reinforce-daily.{sh,mjs}` (daily reminder)
- Skills: `.agents/skills/{distill,reinforce}/` (each SKILL.md ≤150 lines, progressive disclosure to `reference/`)
- Data + shared lib: `.agents/reinforcement-loop/` (`lib.mjs`, `candidates/`, `decisions.jsonl`, `DECISIONS.md`, `REINFORCE-LOG.md`, `state.json`)
- Docs: `docs/agents/reinforcement-loop.md`; `AGENTS.md` map + skills entries

## Test plan
- ✅ `npm test` — 529 passed (41 files)
- ✅ `npm run build` — succeeds, no sourcemaps in `dist/`
- ✅ Stage 0 capture verified against a real transcript (733KB → 30KB filtered, −96%; home paths scrubbed, 0 leaks)
- ✅ `/distill --dry` selection + tally promotion (count≥2, cross-user) + idempotency via `decisions.jsonl` verified
- ✅ SessionStart daily check: silent when nothing due, correct reminder when due, recursion-guard verified
- ✅ Security: no secrets / `.env` / keys in diff, no `src/` changes (XSS/feed surface untouched), no keys in bundle. `npm audit` high (undici) is a pre-existing transitive dep — this PR adds no npm dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)