### PR TITLE
PRD #136: Expected-impact projection slices 5 & 6

### DIFF
--- a/src/components/CommandCenter.jsx
+++ b/src/components/CommandCenter.jsx
@@ -51,6 +51,29 @@ export function CommandCenter({ vehicles = [], feeds = [], theme = 'light', MapC
   const zoom = focus ? INCIDENT_FOCUS_ZOOM : 6;
   const highlightedVehicleIds = focus ? focus.vehicleIds : [];
 
+  // Downstream accent (PRD #136, stories 11/12): the deduped union of the
+  // selected Incident projection's Downstream vehicles, surfaced through a
+  // channel separate from the highlight so a forecast never reads as an
+  // observation on the map. Empty when there is no projection — operator-subject
+  // Incidents (projection always null) and retracted forecasts disappear for
+  // free. The highlighted (stalled) vehicles are excluded so a vehicle is never
+  // both selected and predicted.
+  const predictedVehicleIds = useMemo(() => {
+    const affected = selectedIncident?.projection?.affected;
+    if (!affected) return [];
+    const highlighted = new Set(highlightedVehicleIds);
+    const ids = [];
+    const seen = new Set();
+    for (const a of affected) {
+      for (const id of a.downstreamVehicleIds ?? []) {
+        if (highlighted.has(id) || seen.has(id)) continue;
+        seen.add(id);
+        ids.push(id);
+      }
+    }
+    return ids;
+  }, [selectedIncident, highlightedVehicleIds]);
+
   return (
     <div className="command-center">
       <aside className="command-center__inbox" aria-label="Incident inbox">
@@ -76,6 +99,7 @@ export function CommandCenter({ vehicles = [], feeds = [], theme = 'light', MapC
           zoom={zoom}
           theme={theme}
           highlightedVehicleIds={highlightedVehicleIds}
+          predictedVehicleIds={predictedVehicleIds}
         />
         {selectedIncident?.demo && (
           <div className="command-center__demo-overlay" role="note">

--- a/src/components/CommandCenter.test.jsx
+++ b/src/components/CommandCenter.test.jsx
@@ -57,6 +57,81 @@ describe('CommandCenter', () => {
     expect(props.last.highlightedVehicleIds).toEqual(['sl:bus-1']);
   });
 
+  describe('downstream accent on the map (PRD #136)', () => {
+    // A stalled bus plus a same-line+direction downstream bus near enough to be
+    // forecast as degrading. The downstream bus keeps moving (it is approaching,
+    // not stalled) so it forms no Incident of its own — leaving exactly one
+    // "Line 4" row to select. `poll` shifts its position so it never trips the
+    // stationary rule. Mirrors the useIncidents projection fixture.
+    const stalledPlusDownstream = (stalledLng = 18.0686, poll = 0) => [
+      { id: 'sl:bus-1', operator: 'sl', line: '4', direction: '0', tripId: 'trip-abc', latitude: 59.3293, longitude: stalledLng },
+      { id: 'sl:bus-2', operator: 'sl', line: '4', direction: '0', tripId: 'trip-def', latitude: 59.31, longitude: 18.06 + poll * 0.001 },
+    ];
+
+    it('accents the selected geographic Incident\'s downstream (forecast) vehicles, distinct from the highlight', () => {
+      const { FakeMap, props } = makeFakeMap();
+      let t = 0;
+      const now = () => t;
+
+      const { rerender } = render(
+        <CommandCenter vehicles={stalledPlusDownstream(18.0686, 0)} MapComponent={FakeMap} now={now} />,
+      );
+      act(() => { t = 6 * MIN; });
+      rerender(<CommandCenter vehicles={stalledPlusDownstream(18.0686, 1)} MapComponent={FakeMap} now={now} />);
+
+      // No selection yet ⇒ no forecast accent.
+      expect(props.last.predictedVehicleIds).toEqual([]);
+
+      fireEvent.click(screen.getByRole('button', { name: /Line 4/ }));
+
+      // The Downstream vehicle is accented, and the accent channel is separate
+      // from the selection/highlight channel (the stalled bus is highlighted,
+      // the downstream bus is predicted — never the same id in both).
+      expect(props.last.predictedVehicleIds).toContain('sl:bus-2');
+      expect(props.last.predictedVehicleIds).not.toContain('sl:bus-1');
+      expect(props.last.highlightedVehicleIds).toContain('sl:bus-1');
+    });
+
+    it('shows no downstream accent when the projection retracts between polls', () => {
+      const { FakeMap, props } = makeFakeMap();
+      let t = 0;
+      const now = () => t;
+
+      const { rerender } = render(
+        <CommandCenter vehicles={stalledPlusDownstream(18.0686, 0)} MapComponent={FakeMap} now={now} />,
+      );
+      act(() => { t = 6 * MIN; });
+      rerender(<CommandCenter vehicles={stalledPlusDownstream(18.0686, 1)} MapComponent={FakeMap} now={now} />);
+      fireEvent.click(screen.getByRole('button', { name: /Line 4/ }));
+      expect(props.last.predictedVehicleIds).toContain('sl:bus-2');
+
+      // Next poll: the stalled bus has driven away — the projection retracts.
+      act(() => { t = 7 * MIN; });
+      rerender(<CommandCenter vehicles={stalledPlusDownstream(18.2, 2)} MapComponent={FakeMap} now={now} />);
+
+      expect(props.last.predictedVehicleIds).toEqual([]);
+    });
+
+    it('shows no downstream accent for an operator-subject (feed outage) Incident', () => {
+      const { FakeMap, props } = makeFakeMap();
+      let t = 0;
+      const now = () => t;
+      const failFeeds = () => [{ operator: 'sl', ok: false, vehicleCount: 0, dataTimestamp: null }];
+
+      const { rerender } = render(
+        <CommandCenter vehicles={[]} feeds={failFeeds()} MapComponent={FakeMap} now={now} />,
+      );
+      for (let i = 1; i <= 3; i++) {
+        act(() => { t = i * MIN; });
+        rerender(<CommandCenter vehicles={[]} feeds={failFeeds()} MapComponent={FakeMap} now={now} />);
+      }
+
+      fireEvent.click(screen.getByRole('button', { name: /Feed outage · SL/ }));
+
+      expect(props.last.predictedVehicleIds).toEqual([]);
+    });
+  });
+
   it('shows the selected Incident\'s why-flagged panel and timeline', () => {
     const { FakeMap } = makeFakeMap();
     let t = 0;

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -9,7 +9,7 @@ import { createMarkerCollection } from '../services/markerCollection';
 import { createVehicleAdapter, FULL_MARKER_MIN_ZOOM } from '../services/vehicleAdapter';
 import { createWebcamAdapter } from '../services/webcamAdapter';
 
-const EMPTY_HIGHLIGHTED_VEHICLE_IDS = [];
+const EMPTY_VEHICLE_IDS = [];
 
 function haveSameOrderedIds(previousIds, nextIds) {
   if (previousIds.length !== nextIds.length) return false;
@@ -19,16 +19,22 @@ function haveSameOrderedIds(previousIds, nextIds) {
   return true;
 }
 
+function createIdSetState(ids) {
+  return {
+    ids: ids.slice(),
+    idSet: new Set(ids),
+  };
+}
+
 function createHighlightState(highlightedVehicleIds) {
   return {
-    ids: highlightedVehicleIds.slice(),
-    idSet: new Set(highlightedVehicleIds),
+    ...createIdSetState(highlightedVehicleIds),
     vehicles: null,
     mapZoom: null,
   };
 }
 
-export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = EMPTY_HIGHLIGHTED_VEHICLE_IDS, userLocation = null }) {
+export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = EMPTY_VEHICLE_IDS, predictedVehicleIds = EMPTY_VEHICLE_IDS, userLocation = null }) {
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
   // Singleton User location marker (PRD #111). A single circle marker managed
@@ -39,6 +45,12 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   // Highlight set is read live by the adapter so selection changes are reflected.
   const [initialHighlightState] = useState(() => createHighlightState(highlightedVehicleIds));
   const highlightStateRef = useRef(initialHighlightState);
+  // Predicted (Downstream) set: a selected Incident projection's forecast (PRD
+  // #136). Read live by the adapter, parallel to the highlight set, so a
+  // forecast accent never reads as the observed selection. Empty in the plain
+  // map view and whenever the projection is null/retracted.
+  const [initialPredictedState] = useState(() => createIdSetState(predictedVehicleIds));
+  const predictedStateRef = useRef(initialPredictedState);
   // Current zoom, read live by the adapter; mapZoom state re-triggers the
   // marker-update effect so existing markers swap compact/full icons on zoom.
   const zoomRef = useRef(zoom);
@@ -46,6 +58,7 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   const vehicleAdapterRef = useRef(
     createVehicleAdapter({
       isHighlighted: (id) => highlightStateRef.current.idSet.has(id),
+      isPredicted: (id) => predictedStateRef.current.idSet.has(id),
       getZoom: () => zoomRef.current,
     }),
   );
@@ -151,8 +164,9 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   }, [center, zoom]);
 
   // Update vehicle markers via the marker-collection module. Runs after render
-  // so highlight bookkeeping stays out of render; the equality gate prevents
-  // marker churn unless vehicles, ordered highlights, or zoom actually changed.
+  // so highlight/predicted bookkeeping stays out of render; the equality gate
+  // prevents marker churn unless vehicles, ordered highlights, the predicted
+  // (Downstream) set, or zoom actually changed.
   useEffect(() => {
     const highlightState = highlightStateRef.current;
     const highlightsChanged = !haveSameOrderedIds(highlightState.ids, highlightedVehicleIds);
@@ -161,9 +175,16 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
       highlightState.idSet = new Set(highlightedVehicleIds);
     }
 
+    const predictedState = predictedStateRef.current;
+    const predictedChanged = !haveSameOrderedIds(predictedState.ids, predictedVehicleIds);
+    if (predictedChanged) {
+      predictedState.ids = predictedVehicleIds.slice();
+      predictedState.idSet = new Set(predictedVehicleIds);
+    }
+
     const vehiclesChanged = highlightState.vehicles !== vehicles;
     const zoomChanged = highlightState.mapZoom !== mapZoom;
-    if (!vehiclesChanged && !highlightsChanged && !zoomChanged) return;
+    if (!vehiclesChanged && !highlightsChanged && !predictedChanged && !zoomChanged) return;
 
     highlightState.vehicles = vehicles;
     highlightState.mapZoom = mapZoom;

--- a/src/services/etaProjection.js
+++ b/src/services/etaProjection.js
@@ -21,8 +21,15 @@
 // by direction-known, the count of fresh downstream observations, and their
 // recency. Below CONFIDENCE_FLOOR the entry is suppressed; with none surviving
 // the whole Projection is null — silence over a guess (stories 5/6).
+//
+// Slice 6 generalises the Projection to carry one structured entry per affected
+// (line, direction): a geographic Incident can merge several stalled vehicles
+// (within PROXIMITY_THRESHOLD_M of its subject) across several lines or both
+// directions of one line, so a multi-line disruption is fully covered with one
+// entry each, while a single-line/direction Incident yields exactly one (story 14).
 
-import { distanceMeters, DISPLACEMENT_THRESHOLD_M } from './anomalyRules';
+import { distanceMeters } from './anomalyRules';
+import { PROXIMITY_THRESHOLD_M } from './incidentClustering';
 
 // Distance cap on the Downstream set: a same-line/direction vehicle further
 // behind than this is too far back to be attributed to this disruption.
@@ -225,16 +232,21 @@ export function predictImpact(incident, buffer, now) {
     const stalled = byId.get(vehicleId);
     if (!stalled) continue; // gone from the feed — no current basis
 
-    // Still stalled? If the vehicle has progressed beyond the displacement
-    // threshold of the Incident's stall point, the disruption has cleared for
-    // it and the forecast retracts.
+    // Still part of the stall cluster? A geographic Incident merges several
+    // stalled vehicles within PROXIMITY_THRESHOLD_M of its subject (one per
+    // (line, direction) in a multi-line disruption — see incidentClustering),
+    // so a stalled vehicle is still part of the disruption while it sits within
+    // that same radius. Once it has progressed beyond it the disruption has
+    // cleared for that vehicle and its forecast retracts. Using the clustering
+    // radius (not the tighter displacement threshold) keeps every merged stall
+    // eligible, so multi-line / multi-direction Incidents yield an entry each.
     if (
       distanceMeters(
         stalled.latitude,
         stalled.longitude,
         incident.subject.latitude,
         incident.subject.longitude,
-      ) > DISPLACEMENT_THRESHOLD_M
+      ) > PROXIMITY_THRESHOLD_M
     ) {
       continue;
     }

--- a/src/services/etaProjection.test.js
+++ b/src/services/etaProjection.test.js
@@ -241,6 +241,76 @@ describe('predictImpact', () => {
     expect(predictImpact(geographicIncident(), buffer, 30 * MIN)).toBeNull();
   });
 
+  // --- Slice 6: per-(line, direction) projection entries (PRD #136, issue #142) ---
+
+  it('emits one entry per line when an Incident spans two distinct lines', () => {
+    // Two buses stalled close together (clusterIncidents merges them within
+    // PROXIMITY_THRESHOLD_M into one geographic Incident) but on different lines,
+    // each with its own downstream vehicle. The projection carries one entry per
+    // (line, direction).
+    const stalled4 = vehicle({ id: 'sl:bus-1', line: '4', direction: '0' });
+    const behind4 = vehicle({ id: 'sl:bus-2', line: '4', direction: '0', latitude: 59.31, longitude: 18.06 });
+    // Second stall ~120 m away (inside the 250 m clustering radius, outside the
+    // 30 m displacement threshold) on a different line.
+    const stalled6 = vehicle({ id: 'sl:bus-3', line: '6', direction: '0', latitude: 59.3304, longitude: 18.0686 });
+    const behind6 = vehicle({ id: 'sl:bus-4', line: '6', direction: '0', latitude: 59.31, longitude: 18.06 });
+    const buffer = [snapshot([stalled4, behind4, stalled6, behind6])];
+    const incident = geographicIncident({
+      lines: ['4', '6'],
+      vehicleIds: ['sl:bus-1', 'sl:bus-3'],
+    });
+
+    const projection = predictImpact(incident, buffer, 6 * MIN);
+
+    expect(projection).not.toBeNull();
+    expect(projection.affected).toHaveLength(2);
+    const lines = projection.affected.map((a) => a.line).sort();
+    expect(lines).toEqual(['4', '6']);
+  });
+
+  it('emits one entry per direction when an Incident involves both directions of one line', () => {
+    // Both directions of line 4 stalled near the same point, each with a
+    // same-direction downstream vehicle. Opposite directions must NOT collapse
+    // into one entry, nor leak into each other's downstream set.
+    const stalledOut = vehicle({ id: 'sl:bus-1', line: '4', direction: '0' });
+    const behindOut = vehicle({ id: 'sl:bus-2', line: '4', direction: '0', latitude: 59.31, longitude: 18.06 });
+    const stalledIn = vehicle({ id: 'sl:bus-3', line: '4', direction: '1', latitude: 59.3304, longitude: 18.0686 });
+    const behindIn = vehicle({ id: 'sl:bus-4', line: '4', direction: '1', latitude: 59.31, longitude: 18.06 });
+    const buffer = [snapshot([stalledOut, behindOut, stalledIn, behindIn])];
+    const incident = geographicIncident({
+      lines: ['4'],
+      vehicleIds: ['sl:bus-1', 'sl:bus-3'],
+    });
+
+    const projection = predictImpact(incident, buffer, 6 * MIN);
+
+    expect(projection).not.toBeNull();
+    expect(projection.affected).toHaveLength(2);
+    const directions = projection.affected.map((a) => a.direction).sort();
+    expect(directions).toEqual(['0', '1']);
+    // No cross-contamination of downstream sets between directions.
+    const out = projection.affected.find((a) => a.direction === '0');
+    const inb = projection.affected.find((a) => a.direction === '1');
+    expect(out.downstreamVehicleIds).toEqual(['sl:bus-2']);
+    expect(inb.downstreamVehicleIds).toEqual(['sl:bus-4']);
+  });
+
+  it('emits exactly one entry, with no duplication, for a single line and direction', () => {
+    // The Incident lists the same stalled vehicle twice (e.g. two polls folded
+    // the same anomaly) — the projection must still yield exactly one entry.
+    const stalled = vehicle({ id: 'sl:bus-1', line: '4', direction: '0' });
+    const behind = vehicle({ id: 'sl:bus-2', line: '4', direction: '0', latitude: 59.31, longitude: 18.06 });
+    const buffer = [snapshot([stalled, behind])];
+    const incident = geographicIncident({ vehicleIds: ['sl:bus-1', 'sl:bus-1'] });
+
+    const projection = predictImpact(incident, buffer, 6 * MIN);
+
+    expect(projection).not.toBeNull();
+    expect(projection.affected).toHaveLength(1);
+    expect(projection.affected[0].line).toBe('4');
+    expect(projection.affected[0].direction).toBe('0');
+  });
+
   describe('coarseDelayLabel buckets magnitude without false precision', () => {
     it.each([
       [3, '~5 min'],

--- a/src/services/vehicleAdapter.js
+++ b/src/services/vehicleAdapter.js
@@ -23,13 +23,19 @@ export function vehiclePopupContent(vehicle) {
 export const FULL_MARKER_MIN_ZOOM = 12;
 
 /**
- * @param {{ isHighlighted?: (vehicleId: string) => boolean, getZoom?: () => number }} [opts]
+ * @param {{ isHighlighted?: (vehicleId: string) => boolean, isPredicted?: (vehicleId: string) => boolean, getZoom?: () => number }} [opts]
  *   isHighlighted lets the command-center view highlight vehicles involved in a
  *   selected Incident. Default: nothing highlighted (existing map view behaviour).
+ *   isPredicted accents Downstream vehicles a selected Incident's projection
+ *   forecasts will degrade (PRD #136). Styled distinctly from the highlight — a
+ *   dashed violet ring vs the solid gold selection — so a forward-looking
+ *   Projection never reads as an observed selection on the ground. The highlight
+ *   (observation) wins when a vehicle is both. Default: nothing predicted
+ *   (existing map view behaviour).
  *   getZoom supplies the current map zoom; below FULL_MARKER_MIN_ZOOM markers
  *   render compact. Default: always full-size.
  */
-export function createVehicleAdapter({ isHighlighted = () => false, getZoom = () => FULL_MARKER_MIN_ZOOM } = {}) {
+export function createVehicleAdapter({ isHighlighted = () => false, isPredicted = () => false, getZoom = () => FULL_MARKER_MIN_ZOOM } = {}) {
   const markerVehicles = new WeakMap();
   const markerVisualStateKeys = new WeakMap();
 
@@ -37,15 +43,21 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
     const color = MODE_COLORS[vehicle.mode] || MODE_COLORS.unknown;
     const icon = MODE_ICONS[vehicle.mode] || MODE_ICONS.unknown;
     const highlighted = isHighlighted(vehicle.id);
-    const compact = !highlighted && getZoom() < FULL_MARKER_MIN_ZOOM;
+    // The selection/highlight (an observation) always wins over a prediction so
+    // a Downstream-vehicle accent never overrides the observed selection.
+    const predicted = !highlighted && isPredicted(vehicle.id);
+    // Predicted vehicles stay full-size (like highlighted) so the accent is
+    // legible even when the surrounding field is clustered/compact.
+    const compact = !highlighted && !predicted && getZoom() < FULL_MARKER_MIN_ZOOM;
     const label = vehicle.line?.length <= 3 ? ['line', String(vehicle.line ?? '')] : ['icon', icon];
 
     return {
       color,
       icon,
       highlighted,
+      predicted,
       compact,
-      key: JSON.stringify([compact, color, highlighted, label]),
+      key: JSON.stringify([compact, color, highlighted, predicted, label]),
     };
   }
 
@@ -81,12 +93,23 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
     if (state.compact) {
       return buildCompactIcon(state.color);
     }
-    const border = state.highlighted ? '3px solid #ffd400' : '2px solid white';
-    const shadow = state.highlighted
-      ? '0 0 0 3px rgba(255,212,0,0.5), 0 2px 4px rgba(0,0,0,0.3)'
-      : '0 2px 4px rgba(0,0,0,0.3)';
+    let border = '2px solid white';
+    let shadow = '0 2px 4px rgba(0,0,0,0.3)';
+    let className = 'vehicle-marker';
+    if (state.highlighted) {
+      // Observed selection: solid gold ring.
+      border = '3px solid #ffd400';
+      shadow = '0 0 0 3px rgba(255,212,0,0.5), 0 2px 4px rgba(0,0,0,0.3)';
+      className = 'vehicle-marker vehicle-marker--highlighted';
+    } else if (state.predicted) {
+      // Forecast (Projection): dashed violet ring — deliberately unlike the
+      // gold selection so a prediction never reads as an observation.
+      border = '2px dashed #8a6dff';
+      shadow = '0 0 0 3px rgba(138,109,255,0.35), 0 2px 4px rgba(0,0,0,0.3)';
+      className = 'vehicle-marker vehicle-marker--predicted';
+    }
     return L.divIcon({
-      className: state.highlighted ? 'vehicle-marker vehicle-marker--highlighted' : 'vehicle-marker',
+      className,
       html: `
           <div style="
             background: ${state.color};

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -120,6 +120,66 @@ describe('createVehicleAdapter zoom-adaptive icons', () => {
   });
 });
 
+describe('createVehicleAdapter downstream prediction accent', () => {
+  it('accents predicted (downstream) vehicles distinctly from highlighted ones', () => {
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isPredicted: (id) => id === 'v1',
+    });
+    const icon = adapter.toIcon(makeVehicle());
+
+    // A prediction must never read as the observed selection/highlight.
+    expect(icon.className).toContain('vehicle-marker--predicted');
+    expect(icon.className).not.toContain('vehicle-marker--highlighted');
+  });
+
+  it('keeps predicted vehicles full-size even below the zoom threshold', () => {
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM - 3,
+      isPredicted: (id) => id === 'v1',
+    });
+    const icon = adapter.toIcon(makeVehicle());
+    expect(icon.iconSize).toEqual([24, 24]);
+  });
+
+  it('lets the selection/highlight win when a vehicle is both highlighted and predicted', () => {
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isHighlighted: (id) => id === 'v1',
+      isPredicted: (id) => id === 'v1',
+    });
+    const icon = adapter.toIcon(makeVehicle());
+    expect(icon.className).toContain('vehicle-marker--highlighted');
+    expect(icon.className).not.toContain('vehicle-marker--predicted');
+  });
+
+  it('replaces the icon when prediction state changes', () => {
+    let predicted = false;
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isPredicted: () => predicted,
+    });
+    const marker = {
+      setLatLng: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      isPopupOpen: () => false,
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    predicted = true;
+    adapter.onUpdate(marker, makeVehicle());
+
+    expect(marker.setIcon).toHaveBeenCalledOnce();
+    expect(marker.setIcon.mock.calls[0][0].className).toContain('vehicle-marker--predicted');
+  });
+
+  it('defaults to nothing predicted (existing map view behaviour)', () => {
+    const adapter = createVehicleAdapter();
+    const icon = adapter.toIcon(makeVehicle());
+    expect(icon.className).not.toContain('vehicle-marker--predicted');
+  });
+});
+
 describe('createVehicleAdapter lazy popups', () => {
   it('defers vehicle popup formatting until Leaflet resolves popup content', () => {
     const adapter = createVehicleAdapter();


### PR DESCRIPTION
## Summary

Implements the two remaining open slices of **PRD #136 — Predictive ETA degradation (Expected-impact Projection)**, built via the `/dynamic-tdd` workflow (plan → parallel TDD in isolated worktrees → merge into one feature branch).

- **[Slice 5] Downstream accent on the map (#141)** — a subtle downstream accent for the selected Incident's projection via a new `predictedVehicleIds` channel, styled distinctly from selection/highlight so a prediction never reads as a ground observation. Updates between polls and clears when the projection is null or the Incident is operator-subject. Touches `Map.jsx`, `vehicleAdapter.js`, `CommandCenter.jsx`.
- **[Slice 6] Per-(line, direction) projection entries (#142)** — generalises the projection shape to per-(line, direction) entries. Touches `etaProjection.js`.

## Test plan

- `npm test` — **540 passed** (includes new tests beside `etaProjection`, `vehicleAdapter`, `CommandCenter`).
- `npm run build` — succeeds; sourcemaps stay off (no `.map` in `dist/`).
- Security analysis — no XSS vectors, no committed secrets; bundled API key and `npm audit` high are pre-existing (this diff touches no env/key/dep files).

Closes #141
Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)