### PR TITLE
Add /dynamic-tdd skill — PRD → feature branch → parallel TDD build

### DIFF
--- a/.agents/skills/dynamic-tdd/SKILL.md
+++ b/.agents/skills/dynamic-tdd/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: dynamic-tdd
+description: Build every open issue under a PRD automatically using a dynamic Workflow — plan (dependency graph) → parallel TDD implement in isolated worktrees → merge each issue branch into one feature branch → open a single PR into develop. Use when the user runs /dynamic-tdd <PRD#>, wants to auto-build a PRD's child issues, or asks to orchestrate issues with the Workflow tool / sandcastle-style flow.
+---
+
+# dynamic-tdd
+
+Replaces the `.sandcastle` plan→implement→merge loop with the **Workflow tool**, integrating into a feature branch instead of pushing to trunk.
+
+**Branch model:** `develop` → `feature/<prd-slug>` → per-issue worktrees (`dynamic-tdd/issue-<id>`) → merge each back into the feature branch → **one PR** `feature/<prd-slug>` → `develop`. Never push to `develop`/`main` directly (see CLAUDE.md).
+
+Phase prompts live in [reference/](reference/) (`plan-prompt.md`, `implement-prompt.md`, `merge-prompt.md`) and are adapted from `.sandcastle/*-prompt.md`. The Workflow agents read and follow them.
+
+## Run
+
+1. **Resolve the PRD.** Take the number from `/dynamic-tdd <PRD#>`; if absent, ask. Read it and list its open children:
+   ```bash
+   gh issue view <PRD#> --json number,title,body
+   gh issue list --state open --json number,title,body --jq '[.[] | select(.body | test("#<PRD#>")) | {number,title}]'
+   ```
+   If there are zero children, stop and tell the user.
+
+2. **Confirm scope + branch name with the user** (this run will create commits and merges). Derive a slug from the PRD title → `feature/<prd-slug>`. Show the PRD, the child issues, and the branch name; get a go-ahead.
+
+3. **Prep git** (must end on the feature branch in the main worktree — the merger and worktree bases depend on it):
+   ```bash
+   git fetch origin
+   git switch -c feature/<prd-slug> origin/develop   # base off latest develop
+   ```
+   If the branch already exists, `git switch feature/<prd-slug>` and reuse it (the run is resumable — branch names are deterministic).
+
+4. **Run the Workflow** (it loops plan→implement→merge until nothing is unblocked):
+   ```
+   Workflow({
+     scriptPath: ".agents/skills/dynamic-tdd/scripts/dynamic-tdd.workflow.mjs",
+     args: { prd: "<PRD#>", featureBranch: "feature/<prd-slug>", base: "develop", maxIterations: 10, maxParallel: 6 }
+   })
+   ```
+   Wait for the `<task-notification>`; watch live with `/workflows`.
+
+5. **Review, then open ONE PR.** Inspect the feature branch (`git log --oneline origin/develop..`, run `npm run build`). Then open the PR via the [create-pr](../create-pr/SKILL.md) skill with base `develop`. The PR body should list the issues built (and `Closes #<id>` for each so they close on merge).
+
+## Notes
+
+- **Isolation:** each implementer runs with `isolation: 'worktree'` so parallel agents never collide; they share the git object store, so the `dynamic-tdd/issue-<id>` branches are visible to the merger. The merger runs with **no** isolation (in the main worktree, on the feature branch).
+- **Per-iteration incrementality:** later iterations branch off the feature branch's *current* HEAD, so issues unblocked by earlier merges build on top of them.
+- **Issues are not closed mid-run** — completion happens when the single feature PR merges.
+- **Cost:** one Opus planner + N Opus implementers (full TDD) + one merger per iteration. Scale `maxParallel`/`maxIterations` to the backlog; warn the user for large PRDs.
+- **Resumable:** re-running with the same PRD reuses the feature branch and deterministic issue branches; the planner skips ids already merged.
+
+## Unresolved questions
+
+- Should the final feature→develop PR be opened automatically, or always left to the user? (Current: orchestrator opens it in step 5 after review.)
+- Mono-PRD only — cross-PRD batching isn't handled.

--- a/.agents/skills/dynamic-tdd/SKILL.md
+++ b/.agents/skills/dynamic-tdd/SKILL.md
@@ -16,9 +16,10 @@ Phase prompts live in [reference/](reference/) (`plan-prompt.md`, `implement-pro
 1. **Resolve the PRD.** Take the number from `/dynamic-tdd <PRD#>`; if absent, ask. Read it and list its open children:
    ```bash
    gh issue view <PRD#> --json number,title,body
-   gh issue list --state open --json number,title,body --jq '[.[] | select(.body | test("#<PRD#>")) | {number,title}]'
+   # Children = issues whose ## Parent section names #<PRD#> as the PRIMARY (first) parent:
+   gh issue list --state open --json number,title,body --jq '[.[] | select(.body | test("(?i)## *parent")) | {number,title,body}]'
    ```
-   If there are zero children, stop and tell the user.
+   Keep only those whose `## Parent` section lists `#<PRD#>` first — exclude prose mentions, soft deps, and other PRDs' slices. If there are zero children, stop and tell the user.
 
 2. **Confirm scope + branch name with the user** (this run will create commits and merges). Derive a slug from the PRD title → `feature/<prd-slug>`. Show the PRD, the child issues, and the branch name; get a go-ahead.
 

--- a/.agents/skills/dynamic-tdd/SKILL.md
+++ b/.agents/skills/dynamic-tdd/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: dynamic-tdd
-description: Build every open issue under a PRD automatically using a dynamic Workflow — plan (dependency graph) → parallel TDD implement in isolated worktrees → merge each issue branch into one feature branch → open a single PR into develop. Use when the user runs /dynamic-tdd <PRD#>, wants to auto-build a PRD's child issues, or asks to orchestrate issues with the Workflow tool / sandcastle-style flow.
+description: Build every open issue under a PRD automatically — a dynamic Workflow plans (dependency graph) → implements each issue with TDD in isolated worktrees → merges each into one feature branch (deleting each merged worktree) → then simplify → verify in Aspire (web logs) → local Codex PR review → open one PR into develop. Use when the user runs /dynamic-tdd <PRD#>, wants to auto-build a PRD's child issues, or asks to orchestrate issues with the Workflow tool / sandcastle-style flow.
 ---
 
 # dynamic-tdd
 
 Replaces the `.sandcastle` plan→implement→merge loop with the **Workflow tool**, integrating into a feature branch instead of pushing to trunk.
 
-**Branch model:** `develop` → `feature/<prd-slug>` → per-issue worktrees (`dynamic-tdd/issue-<id>`) → merge each back into the feature branch → **one PR** `feature/<prd-slug>` → `develop`. Never push to `develop`/`main` directly (see CLAUDE.md).
+**Branch model:** `develop` → `feature/<prd-slug>` → per-issue worktrees (`dynamic-tdd/issue-<id>`) → merge each back into the feature branch (then delete that worktree) → **one PR** `feature/<prd-slug>` → `develop`. Never push to `develop`/`main` directly (see CLAUDE.md).
 
-Phase prompts live in [reference/](reference/) (`plan-prompt.md`, `implement-prompt.md`, `merge-prompt.md`) and are adapted from `.sandcastle/*-prompt.md`. The Workflow agents read and follow them.
+**Pipeline:** plan → implement (parallel TDD, isolated worktrees) → merge + delete merged worktree → **simplify** → **verify in Aspire** (check web/browser logs) → **local Codex PR review** → **create PR**. The Workflow tool runs the first three (the fan-out); the orchestrator runs the tail (steps 5–8 below), each delegating to an existing skill.
+
+Phase prompts live in [reference/](reference/) (`plan-prompt.md`, `implement-prompt.md`, `merge-prompt.md`, `simplify-prompt.md`, `verify-prompt.md`) and are adapted from `.sandcastle/*-prompt.md`. The agents read and follow them.
 
 ## Run
 
@@ -30,20 +32,30 @@ Phase prompts live in [reference/](reference/) (`plan-prompt.md`, `implement-pro
    ```
    If the branch already exists, `git switch feature/<prd-slug>` and reuse it (the run is resumable — branch names are deterministic).
 
-4. **Run the Workflow** (it loops plan→implement→merge until nothing is unblocked):
+4. **Run the Workflow** (it loops plan→implement→merge until nothing is unblocked; the merge phase deletes each worktree once its branch is merged — see `merge-prompt.md`):
    ```
    Workflow({
      scriptPath: ".agents/skills/dynamic-tdd/scripts/dynamic-tdd.workflow.mjs",
      args: { prd: "<PRD#>", featureBranch: "feature/<prd-slug>", base: "develop", maxIterations: 10, maxParallel: 6 }
    })
    ```
-   Wait for the `<task-notification>`; watch live with `/workflows`.
+   Wait for the `<task-notification>`; watch live with `/workflows`. It returns `{ mergedIssues, ... }`. Confirm `git worktree list` shows only the main worktree afterwards (prune any stragglers: `git worktree prune` + `git worktree remove`).
 
-5. **Review, then open ONE PR.** Inspect the feature branch (`git log --oneline origin/develop..`, run `npm run build`). Then open the PR via the [create-pr](../create-pr/SKILL.md) skill with base `develop`. The PR body should list the issues built (and `Closes #<id>` for each so they close on merge).
+   The remaining steps run **only if `mergedIssues` is non-empty**, in order. Stop and report if any step fails — do not open the PR.
+
+5. **Simplify.** Run the [simplify](../../../.claude/skills/simplify/SKILL.md) skill (`/simplify`) over the feature branch's changed files (`git diff --name-only origin/develop...`). Follow [reference/simplify-prompt.md](reference/simplify-prompt.md). Keep tests green; commit `RALPH: simplify pass (PRD #<PRD#>)` (or nothing if there was nothing to do).
+
+6. **Verify in Aspire.** Run the [observe-running-app](../observe-running-app/SKILL.md) skill (or `/verify`) per [reference/verify-prompt.md](reference/verify-prompt.md): `npm run build`, launch the SPA via **Aspire**, and **verify the browser/web logs are clean** (no new errors/warnings) while exercising each merged slice. **If any merged issue specifies tests that must run in the browser, run them now** against the Aspire app (use `playwright-cli` for scripted steps). If the web logs show a regression or a browser test fails, fix it on the feature branch (tests green) before continuing.
+
+7. **Local Codex PR review.** Ensure Codex is ready (`/codex:setup`), then run a local review of the diff (`git diff origin/develop...`) via the [codex:rescue](../../../.claude/skills/codex/SKILL.md) skill — ask it to review the changes like a PR. Address any blocking findings on the feature branch (commit fixes, keep tests green) and re-run the relevant checks.
+
+8. **Create the PR — only when everything above is OK.** Open ONE PR via the [create-pr](../create-pr/SKILL.md) skill with base `develop`. The body lists the issues built and `Closes #<id>` for each so they close on merge.
 
 ## Notes
 
 - **Isolation:** each implementer runs with `isolation: 'worktree'` so parallel agents never collide; they share the git object store, so the `dynamic-tdd/issue-<id>` branches are visible to the merger. The merger runs with **no** isolation (in the main worktree, on the feature branch).
+- **Worktree cleanup:** the merge phase removes each issue worktree and deletes its branch right after merging it (the Workflow keeps committed worktrees otherwise). After the run, only the main worktree should remain.
+- **Gated tail:** simplify → verify → Codex review → PR run in sequence and each must pass; a failed verify (dirty web logs or a failing browser test) or an unresolved Codex blocker stops the run before the PR.
 - **Per-iteration incrementality:** later iterations branch off the feature branch's *current* HEAD, so issues unblocked by earlier merges build on top of them.
 - **Issues are not closed mid-run** — completion happens when the single feature PR merges.
 - **Cost:** one Opus planner + N Opus implementers (full TDD) + one merger per iteration. Scale `maxParallel`/`maxIterations` to the backlog; warn the user for large PRDs.

--- a/.agents/skills/dynamic-tdd/reference/implement-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/implement-prompt.md
@@ -43,7 +43,13 @@ Use RGR (red-green-refactor) to complete the task. Tests sit beside the file (`*
 
 # FEEDBACK LOOPS
 
-Before committing, run `npm run typecheck` and `npm test` to ensure everything passes. **Both must pass before you commit.**
+You are in a **fresh worktree**, so `node_modules/` will be missing. Install dependencies first:
+
+```
+[ -d node_modules ] || npm install
+```
+
+Then, before committing, run `npm run typecheck` and `npm test` to ensure everything passes. **Both must pass before you commit.**
 
 # COMMIT
 

--- a/.agents/skills/dynamic-tdd/reference/implement-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/implement-prompt.md
@@ -1,0 +1,72 @@
+# TASK
+
+Fix issue {{TASK_ID}}: {{ISSUE_TITLE}}
+
+Pull in the issue using `gh issue view {{TASK_ID}} --comments`. Its parent is **PRD #{{PRD}}** — pull that in too (`gh issue view {{PRD}}`).
+
+Only work on the issue specified.
+
+You are in a **fresh, isolated git worktree** branched off the feature branch. As your **first action**, create the work branch:
+
+```
+git switch -c {{BRANCH}}
+```
+
+Work on `{{BRANCH}}`. Make commits and run tests. Never touch `{{BASE}}`, `develop`, or `main`.
+
+# CONTEXT
+
+Here are the last 10 commits:
+
+<recent-commits>
+
+```
+git log -n 10 --format="%H%n%ad%n%B---" --date=short
+```
+
+</recent-commits>
+
+# EXPLORATION
+
+Explore the repo and fill your context window with relevant information that will allow you to complete the task.
+
+Pay extra attention to test files that touch the relevant parts of the code.
+
+# EXECUTION
+
+Use RGR (red-green-refactor) to complete the task. Tests sit beside the file (`*.test.js` / `*.test.jsx`).
+
+1. RED: write one failing test
+2. GREEN: write the implementation to pass that test
+3. REPEAT until done
+4. REFACTOR the code
+
+# FEEDBACK LOOPS
+
+Before committing, run `npm run typecheck` and `npm test` to ensure everything passes. **Both must pass before you commit.**
+
+# COMMIT
+
+Make a git commit on `{{BRANCH}}`. The commit message must:
+
+1. Start with `RALPH:` prefix
+2. Include task completed + PRD reference (#{{PRD}})
+3. Key decisions made
+4. Files changed
+5. Blockers or notes for next iteration
+
+Keep it concise. Make at least one commit if you produced any passing progress.
+
+# THE ISSUE
+
+If the task is not complete, leave a comment on the issue with what was done.
+
+Do **not** close the issue — completion is handled later when the feature PR merges.
+
+# OUTPUT
+
+Return `{ id, branch, committed, summary }` via the **structured-output tool** — `committed` is `true` if you made at least one commit on `{{BRANCH}}`. (This supersedes the `<promise>COMPLETE</promise>` convention.)
+
+# FINAL RULES
+
+ONLY WORK ON A SINGLE TASK.

--- a/.agents/skills/dynamic-tdd/reference/merge-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/merge-prompt.md
@@ -1,0 +1,29 @@
+# TASK
+
+You are in the main worktree on the **feature branch `{{FEATURE_BRANCH}}`**. Merge the following branches into it:
+
+{{BRANCHES}}
+
+For each branch, **one at a time, in order**:
+
+1. Run `git merge <branch> --no-edit`
+2. If there are merge conflicts, resolve them intelligently by reading both sides and choosing the correct combined behavior
+3. After resolving conflicts, run `npm run typecheck` and `npm test` to verify everything works
+4. If tests fail, fix the issues before proceeding to the next branch
+
+After all branches are merged, make a single commit summarizing the merge if one is needed.
+
+# DO NOT CLOSE ISSUES
+
+Unlike a direct-to-trunk flow, this build integrates into a feature branch. **Do not close any issue here** — the issues are completed when the single feature PR (`{{FEATURE_BRANCH}}` → `{{BASE}}`) is merged later by the orchestrator.
+
+Here are the issues whose branches you merged (for reference only):
+
+{{ISSUES}}
+
+# CONSTRAINTS
+
+- Do **not** push.
+- Do **not** merge into `{{BASE}}`, `develop`, or `main` — only into `{{FEATURE_BRANCH}}`.
+
+When you've merged everything you can, report which branches merged cleanly and any you had to skip (with the reason).

--- a/.agents/skills/dynamic-tdd/reference/merge-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/merge-prompt.md
@@ -10,8 +10,29 @@ For each branch, **one at a time, in order**:
 2. If there are merge conflicts, resolve them intelligently by reading both sides and choosing the correct combined behavior
 3. After resolving conflicts, run `npm run typecheck` and `npm test` to verify everything works
 4. If tests fail, fix the issues before proceeding to the next branch
+5. **Once the branch is merged and tests pass, delete its worktree and the branch** (see CLEANUP) — don't leave stale worktrees behind.
 
 After all branches are merged, make a single commit summarizing the merge if one is needed.
+
+# CLEANUP — remove each merged worktree
+
+Each issue branch was built in its own git worktree. As soon as a branch is successfully merged (step 5 above), remove its worktree and delete the now-merged branch:
+
+1. Locate the worktree for the branch:
+   ```
+   git worktree list --porcelain
+   ```
+   Find the entry whose `branch refs/heads/<branch>` matches, and note its `worktree <path>`.
+2. Remove the worktree:
+   ```
+   git worktree remove --force <worktree-path>
+   ```
+3. Delete the merged branch:
+   ```
+   git branch -d <branch>     # use -D only if you have confirmed it is merged
+   ```
+
+Do this for **every** branch you merge. Never remove the main worktree (the one on `{{FEATURE_BRANCH}}`) or its branch.
 
 # DO NOT CLOSE ISSUES
 

--- a/.agents/skills/dynamic-tdd/reference/plan-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/plan-prompt.md
@@ -1,0 +1,37 @@
+# ISSUES
+
+You are planning a TDD build of **PRD #{{PRD}}**. Discover its open child work-issues:
+
+<issues-json>
+
+```
+gh issue view {{PRD}} --json number,title,body
+gh issue list --state open --json number,title,body,labels,comments \
+  --jq '[.[] | select(.body | test("#{{PRD}}")) | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'
+```
+
+A work-issue belongs to this PRD when its body references `#{{PRD}}` (e.g. a `## Parent` section: `#{{PRD}} — …`).
+
+</issues-json>
+
+Exclude any issue ids already attempted this run: **{{DONE}}**.
+
+# TASK
+
+Analyze the open child issues and build a dependency graph. For each issue, determine whether it **blocks** or **is blocked by** any other open child issue.
+
+An issue B is **blocked by** issue A if:
+
+- B requires code or infrastructure that A introduces
+- B and A modify overlapping files or modules, making concurrent work likely to produce merge conflicts
+- B's requirements depend on a decision or API shape that A will establish
+
+An issue is **unblocked** if it has zero blocking dependencies on other open child issues.
+
+For each unblocked issue, assign a branch name using the exact format `dynamic-tdd/issue-{id}` (no slug or other suffix). This must be deterministic so that re-planning the same issue always produces the same branch name and accumulated progress is preserved.
+
+# OUTPUT
+
+Return your plan via the **structured-output tool** as `{ "issues": [ { "id", "title", "branch" } ] }`. (This supersedes any `<plan>` tag convention — emit the structured object, not tags.)
+
+Include only **unblocked** issues. If every issue is blocked, include the single highest-priority candidate (the one with the fewest or weakest dependencies). If there is nothing to work on at all, return `{ "issues": [] }` so the run can exit cleanly.

--- a/.agents/skills/dynamic-tdd/reference/plan-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/plan-prompt.md
@@ -6,11 +6,18 @@ You are planning a TDD build of **PRD #{{PRD}}**. Discover its open child work-i
 
 ```
 gh issue view {{PRD}} --json number,title,body
-gh issue list --state open --json number,title,body,labels,comments \
-  --jq '[.[] | select(.body | test("#{{PRD}}")) | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'
+# Pre-filter to issues that have a "## Parent" section (drops PRDs and loose mentions).
+# --limit 200: the default is 30 and will silently truncate larger backlogs.
+gh issue list --state open --limit 200 --json number,title,body,labels,comments \
+  --jq '[.[] | select(.body | test("(?i)## *parent")) | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'
 ```
 
-A work-issue belongs to this PRD when its body references `#{{PRD}}` (e.g. a `## Parent` section: `#{{PRD}} — …`).
+A work-issue belongs to PRD **#{{PRD}}** only when the **first issue reference in its `## Parent` section is `#{{PRD}}`** (its primary parent). A leading `PRD #NNN —` token counts as that reference; refs later on the line or in parentheses are secondary. EXCLUDE issues that:
+
+- merely mention `#{{PRD}}` in prose or in a parenthetical aside,
+- list `#{{PRD}}` only as a *secondary* / *soft* dependency (not the first ref in `## Parent`),
+- have a different PRD as their primary parent, or
+- are themselves a PRD (title starts with `[PRD]`).
 
 </issues-json>
 
@@ -26,12 +33,14 @@ An issue B is **blocked by** issue A if:
 - B and A modify overlapping files or modules, making concurrent work likely to produce merge conflicts
 - B's requirements depend on a decision or API shape that A will establish
 
-An issue is **unblocked** if it has zero blocking dependencies on other open child issues.
+**Resolve blocker state — do not infer from absence.** Issues often encode dependencies as free text (`## Blocked by #NNN`). Such a dependency is **live only if `#NNN` is itself an OPEN child in this set**. A blocker that is **closed/merged is already satisfied — ignore it.** Check the state of any referenced blocker explicitly (`gh issue view #NNN --json state`) rather than assuming it is open. **Soft / secondary dependencies never block.**
+
+An issue is **unblocked** if it has zero *live* blocking dependencies on other open child issues.
 
 For each unblocked issue, assign a branch name using the exact format `dynamic-tdd/issue-{id}` (no slug or other suffix). This must be deterministic so that re-planning the same issue always produces the same branch name and accumulated progress is preserved.
 
 # OUTPUT
 
-Return your plan via the **structured-output tool** as `{ "issues": [ { "id", "title", "branch" } ] }`. (This supersedes any `<plan>` tag convention — emit the structured object, not tags.)
+Return your plan via the **structured-output tool** as `{ "issues": [ { "id", "title", "branch" } ] }`, where `id` is the issue number **as a string** (e.g. `"141"`) and `branch` is exactly `dynamic-tdd/issue-{id}`. (This supersedes any `<plan>` tag convention — emit the structured object, not tags.)
 
 Include only **unblocked** issues. If every issue is blocked, include the single highest-priority candidate (the one with the fewest or weakest dependencies). If there is nothing to work on at all, return `{ "issues": [] }` so the run can exit cleanly.

--- a/.agents/skills/dynamic-tdd/reference/simplify-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/simplify-prompt.md
@@ -1,0 +1,35 @@
+# TASK
+
+You are in the main worktree on branch `{{FEATURE_BRANCH}}`. All issue branches for **PRD #{{PRD}}** have been merged in. Do a focused simplification pass over **only the code this feature branch changed** relative to `{{BASE}}`.
+
+If the project has a `simplify` skill, follow it. Otherwise apply its intent directly.
+
+# SCOPE
+
+Limit yourself to the changed files:
+
+```
+git diff --name-only origin/{{BASE}}...{{FEATURE_BRANCH}}
+```
+
+Review them for: duplication / missed reuse, dead code, unnecessary complexity, inefficiency, and wrong altitude (logic living in the wrong layer). Apply only **safe, behaviour-preserving** cleanups.
+
+Do **not**:
+
+- change behaviour or public APIs,
+- touch files outside the changed set,
+- "improve" code unrelated to this PRD's slices.
+
+# GATE
+
+After each cleanup run `npm run typecheck` and `npm test`. Both must stay green — revert any change that breaks them.
+
+# COMMIT
+
+If you made changes, commit them on `{{FEATURE_BRANCH}}`:
+
+```
+RALPH: simplify pass (PRD #{{PRD}})
+```
+
+…summarizing what you consolidated. If nothing genuinely needed simplifying, make **no** commit and say so. Do not push. Report what you changed (or that you changed nothing and why).

--- a/.agents/skills/dynamic-tdd/reference/verify-prompt.md
+++ b/.agents/skills/dynamic-tdd/reference/verify-prompt.md
@@ -1,0 +1,17 @@
+# TASK
+
+You are on branch `{{FEATURE_BRANCH}}` with **PRD #{{PRD}}**'s slices merged and simplified. Verify the change actually **works at runtime** — not just that tests pass.
+
+**Run it in Aspire.** Use the `observe-running-app` skill (Aspire AppHost) — that is how this project observes real browser console / network / JS errors, not just Vite stdout.
+
+1. Build: `npm run build` must succeed.
+2. Launch the SPA via **Aspire** (`observe-running-app` skill / `aspire start`) and confirm it **boots** and the GTFS-RT polling runs.
+3. **Verify the web logs.** Inspect the **browser console logs** captured by Aspire (browser-log capture / the Aspire dashboard). The change is only verified if the web logs show **no new errors or warnings** introduced by the merged slices. Quote the relevant log lines (or confirm they are clean) in your verdict.
+4. For each merged issue, exercise the behaviour it introduced (per the issue's acceptance criteria) and confirm it appears and behaves correctly in the running app, watching the web logs as you do.
+5. **Browser tests from the issues.** Read each merged issue (`gh issue view <id> --comments`). If an issue specifies tests or acceptance checks that must be **run in the browser / web** (manual steps, Playwright/e2e scenarios, "verify in the UI that…"), **run them now** against the Aspire-launched app — use the `playwright-cli` skill for scripted browser steps, or drive the UI manually and observe. Report each browser test and its result (pass/fail) in the verdict. A failing browser test means overall `FAIL`.
+
+# OUTPUT
+
+Report a concise **VERDICT**: what you checked, what passed, and any runtime problems found. State `PASS` or `FAIL` overall.
+
+Do **not** commit and do **not** push. If you find a real runtime regression, describe it precisely (steps, expected vs actual) so the orchestrator can decide whether to fix before opening the PR.

--- a/.agents/skills/dynamic-tdd/scripts/dynamic-tdd.workflow.mjs
+++ b/.agents/skills/dynamic-tdd/scripts/dynamic-tdd.workflow.mjs
@@ -9,7 +9,10 @@ export const meta = {
 }
 
 // args (passed by the orchestrator): { prd, featureBranch, base?, maxIterations?, maxParallel? }
-const { prd, featureBranch, base = 'develop', maxIterations = 10, maxParallel = 6 } = args || {}
+// Tolerate args arriving as a JSON-encoded string (the Workflow tool may stringify it).
+let _args = args
+if (typeof _args === 'string') { try { _args = JSON.parse(_args) } catch { _args = {} } }
+const { prd, featureBranch, base = 'develop', maxIterations = 10, maxParallel = 6 } = _args || {}
 if (!prd || !featureBranch) throw new Error('dynamic-tdd: args.prd and args.featureBranch are required')
 
 const PLAN_SCHEMA = {

--- a/.agents/skills/dynamic-tdd/scripts/dynamic-tdd.workflow.mjs
+++ b/.agents/skills/dynamic-tdd/scripts/dynamic-tdd.workflow.mjs
@@ -1,0 +1,107 @@
+export const meta = {
+  name: 'dynamic-tdd',
+  description: 'Plan → parallel TDD implement (isolated worktrees) → merge each issue branch into the feature branch, looping over all open issues under a PRD',
+  phases: [
+    { title: 'Plan', detail: 'Opus builds a dependency graph over the PRD child issues; picks unblocked ones' },
+    { title: 'Implement', detail: 'one TDD red-green-refactor agent per unblocked issue, each in its own worktree' },
+    { title: 'Merge', detail: 'merge the branches that produced commits into the feature branch' },
+  ],
+}
+
+// args (passed by the orchestrator): { prd, featureBranch, base?, maxIterations?, maxParallel? }
+const { prd, featureBranch, base = 'develop', maxIterations = 10, maxParallel = 6 } = args || {}
+if (!prd || !featureBranch) throw new Error('dynamic-tdd: args.prd and args.featureBranch are required')
+
+const PLAN_SCHEMA = {
+  type: 'object',
+  required: ['issues'],
+  properties: {
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'title', 'branch'],
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' },
+          branch: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  required: ['id', 'branch', 'committed'],
+  properties: {
+    id: { type: 'string' },
+    branch: { type: 'string' },
+    committed: { type: 'boolean' },
+    summary: { type: 'string' },
+  },
+}
+
+const REF = '.agents/skills/dynamic-tdd/reference'
+const done = new Set()   // issue ids already attempted this run — never re-plan
+const mergedIssues = []
+let dryRounds = 0
+
+for (let iter = 1; iter <= maxIterations; iter++) {
+  // --- Phase 1: Plan -------------------------------------------------------
+  phase('Plan')
+  const plan = await agent(
+    `You are the PLANNER. Read and follow ${REF}/plan-prompt.md exactly.
+Substitutions: {{PRD}} = ${prd}; {{DONE}} = ${[...done].join(', ') || '(none yet)'}.
+Return the plan via the structured-output tool per the file's OUTPUT section.`,
+    { label: `plan:iter-${iter}`, phase: 'Plan', schema: PLAN_SCHEMA },
+  )
+
+  const todo = (plan?.issues || []).filter((i) => !done.has(String(i.id))).slice(0, maxParallel)
+  if (!todo.length) { log(`Iteration ${iter}: no unblocked issues left — stopping.`); break }
+  log(`Iteration ${iter}: implementing ${todo.length} issue(s): ${todo.map((i) => '#' + i.id).join(', ')}`)
+
+  // --- Phase 2: Implement (parallel, isolated worktrees) -------------------
+  // Barrier is intentional: the merge phase needs ALL completed branches together.
+  const built = await parallel(
+    todo.map((issue) => () =>
+      agent(
+        `You are an IMPLEMENTER. Read and follow ${REF}/implement-prompt.md exactly.
+Substitutions: {{TASK_ID}} = ${issue.id}; {{ISSUE_TITLE}} = ${issue.title}; {{BRANCH}} = ${issue.branch}; {{PRD}} = ${prd}; {{BASE}} = ${base}.
+You are in a fresh isolated git worktree branched off ${featureBranch}. Work ONLY on issue #${issue.id}.
+Return {id, branch, committed, summary} via the structured-output tool per the file's OUTPUT section.`,
+        { label: `tdd:#${issue.id}`, phase: 'Implement', schema: IMPL_SCHEMA, isolation: 'worktree' },
+      ),
+    ),
+  )
+
+  todo.forEach((i) => done.add(String(i.id)))
+  const committed = built.filter(Boolean).filter((b) => b.committed)
+  if (!committed.length) {
+    dryRounds++
+    log(`Iteration ${iter}: no commits produced.`)
+    if (dryRounds >= 2) { log('Two dry rounds — stopping.'); break }
+    continue
+  }
+  dryRounds = 0
+
+  // --- Phase 3: Merge into the feature branch ------------------------------
+  // Runs with NO isolation, in the main worktree which the orchestrator has
+  // checked out to ${featureBranch}. Serial merges so conflicts resolve cleanly.
+  phase('Merge')
+  await agent(
+    `You are the MERGER. Read and follow ${REF}/merge-prompt.md exactly.
+Substitutions:
+  {{FEATURE_BRANCH}} = ${featureBranch}; {{BASE}} = ${base}.
+  {{BRANCHES}} =
+${committed.map((b) => `  - ${b.branch}  (issue #${b.id})`).join('\n')}
+  {{ISSUES}} =
+${committed.map((b) => `  - #${b.id}: ${b.summary || ''}`).join('\n')}
+You are in the main worktree on branch ${featureBranch}.`,
+    { label: `merge:iter-${iter}`, phase: 'Merge' },
+  )
+  mergedIssues.push(...committed.map((b) => b.id))
+  log(`Iteration ${iter}: merged ${committed.length} branch(es) into ${featureBranch}.`)
+}
+
+return { prd, featureBranch, base, mergedIssues, iterations: mergedIssues.length ? 'completed' : 'no-merges' }

--- a/.claude/skills/dynamic-tdd
+++ b/.claude/skills/dynamic-tdd
@@ -1,0 +1,1 @@
+../../.agents/skills/dynamic-tdd


### PR DESCRIPTION
## Summary

Adds the **`/dynamic-tdd <PRD#>`** skill: a dynamic-Workflow build of every open issue under a PRD, integrating into a feature branch (never pushing to trunk).

**Pipeline:** plan (dependency graph over the PRD's child issues) → implement each issue with TDD in isolated worktrees → merge each into one `feature/<prd-slug>` branch and delete the merged worktree → **simplify** → **verify in Aspire** (boot the SPA, confirm browser/web logs are clean, run any browser tests the issues specify) → **local Codex PR review** → open **one** PR into `develop`.

Adapted from the `.sandcastle/*-prompt.md` flow but feature-branch-integrated.

## Contents

- `SKILL.md` — orchestrator runbook (steps 1–8).
- `scripts/dynamic-tdd.workflow.mjs` — the Workflow (plan → implement → merge loop).
- `reference/` — phase prompts: `plan-prompt.md`, `implement-prompt.md`, `merge-prompt.md` (incl. worktree cleanup), `simplify-prompt.md`, `verify-prompt.md`.
- `.claude/skills/dynamic-tdd` symlink so the skill registers.

## Validation

Smoke-tested the planner (read-only) and ran a full end-to-end build on PRD #136 (slices #141/#142): plan correctly selected the true children, both implemented via TDD and merged cleanly, integrated branch green (540 tests, build OK). Hardening from that test is included (primary-parent child discovery, closed-blocker resolution, `--limit 200`, JSON-string args tolerance, fresh-worktree `npm install`).

## Test plan

- `npm test` — 529 passed. `npm run build` — succeeds, sourcemaps off.
- Security — skill files only (markdown + a sandboxed Workflow script); no secrets, no app/runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)