### PR TITLE
Aircraft/helicopter layer + click-to-follow vehicles (PRD #165)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Real-time Leaflet map of Swedish public-transport vehicles, polled ~2s from Traf
 
 ## Response style
 
+- **Always respond in English**, regardless of the language the user writes in.
 - Be extremely concise. Sacrifice grammar for concision.
 - End each plan with a list of unresolved questions.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Real-time Leaflet map of Swedish public-transport vehicles, polled ~2s from Traf
 | [docs/architectural_patterns.md](docs/architectural_patterns.md) | 15 recurring patterns with file:line anchors |
 | [docs/environment.md](docs/environment.md) | env vars, API keys, rate limit, debug scripts |
 | [docs/security-review.md](docs/security-review.md) | mandatory pre-PR security checklist |
-| [docs/adr/](docs/adr/) | ADRs 0001–0006: cookieless, dark tiles, client-side incidents, webcam embeds, transient projections, ephemeral geolocation |
+| [docs/adr/](docs/adr/) | ADRs 0001–0007: cookieless, dark tiles, client-side incidents, webcam embeds, transient projections, ephemeral geolocation, airplanes.live aircraft source |
 | [docs/agents/domain.md](docs/agents/domain.md) | how agents consume CONTEXT.md + ADRs |
 | [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md) | GitHub issue conventions via `gh` |
 | [docs/agents/triage-labels.md](docs/agents/triage-labels.md) | triage label vocabulary |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -129,6 +129,8 @@ A one-way, informational disclosure to the user about what data the app handles 
 
 A Privacy Notice is appropriate when there is nothing being processed conditionally on the user's answer — i.e. when the app has no non-essential storage and no non-essential processing to gate. It discharges transparency and attribution obligations without manufacturing a fake choice.
 
+The notice names every active third-party data source: Trafiklab, OpenStreetMap, the webcam sources, and — for the aircraft layer — **airplanes.live** (linked, annotated that it is fetched only while zoomed in, under Non-Commercial Use with no SLA). airplanes.live is the **same trust category** as the existing third-party fetches, so it needs **no Consent surface** and leaves ADR 0001's cookieless posture intact ([ADR 0007](docs/adr/0007-aircraft-airplanes-live-client-side.md)). Adding it bumped the notice's storage version so every returning user is re-disclosed once.
+
 ### Essential storage
 
 Client-side storage that is **strictly necessary to provide a service the user has explicitly requested**, including the record of the user's own UI choices (such as having acknowledged a Privacy Notice, or having chosen a display theme). Essential storage does not require Consent under EU GDPR / ePrivacy because there is no processing for the user to permit or refuse — the storage *is* the user's own action being remembered.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,9 +14,23 @@ The **vehicle adapter** (`src/services/vehicleAdapter.js`) is the first adapter 
 
 The canonical set of vehicle transport modes, owned entirely by **`src/services/modes.js`**. That module is the single source of truth for the mode list, display label, marker/swatch color, marker icon, and the GTFS `route_type` → mode mapping. All consumers (map renderer, control panel, app state) import from it; none declare their own mode list or color table.
 
-The current canonical modes are: `metro | bus | train | tram | ferry | unknown`.
+A mode is a **vehicle category for marker styling and filtering** — it is *not* defined by GTFS. Most modes derive from a GTFS `route_type` (the `GTFS_ROUTE_TYPE_TO_MODE` table), but a mode may also come from a non-GTFS source: `aircraft` and `helicopter` originate from the airplanes.live feed and have no `route_type`. So `modes.js` owns the full mode list while `GTFS_ROUTE_TYPE_TO_MODE` deliberately covers only the GTFS-sourced subset.
 
-`ship` is not a mode: no GTFS `route_type` in the Swedish feeds maps to it. Route type 1000 (Water Transport) maps to `ferry`.
+The current canonical modes are: `metro | bus | train | tram | ferry | aircraft | helicopter | unknown`.
+
+`ship` is not a mode: no source produces it. GTFS route type 1000 (Water Transport) maps to `ferry`.
+
+## Vehicle
+
+A moving object on the map carrying position, `bearing`, `speed`, a `mode`, and a `line`, managed through the keyed marker-collection. Transit Vehicles come from GTFS-RT and carry an `operator`; an **Aircraft** (mode `aircraft` or `helicopter`, from airplanes.live) is a Vehicle with **no operator**. A User location is not a Vehicle (see above).
+
+A **Line** is a public-transport line designator (a route number such as `4` or `Pendeltåg 41`). An aircraft callsign is **not** a Line: it is carried in the Vehicle's `line` field only to label the marker, and is deliberately excluded from the line filter (Available lines lists transit lines only). Aircraft are filterable by mode, not by callsign.
+
+Aircraft are **not transit observations**: they never enter the command-center pipeline (observation buffer, Anomaly rules, Dwell spots, Feed outage, Projection). A hovering helicopter is not a stationary-vehicle Anomaly, and airplanes.live is not a Watched operator.
+
+## Followed vehicle
+
+A single Vehicle the user has chosen to keep centred: clicking a vehicle's **Follow** control pans the map to it on every position update while keeping the current zoom. It is a **session-only singleton** (forgotten on reload) and orthogonal to the command-center selection/highlight — a vehicle can be both followed and highlighted, and the follow accent composes with the highlight ring rather than replacing it. Following ends when the user stops it, clicks the map background, or the followed Vehicle leaves the feed (exited silently, never an error). Any Vehicle is followable, Aircraft included.
 
 ## User location
 

--- a/docs/adr/0007-aircraft-airplanes-live-client-side.md
+++ b/docs/adr/0007-aircraft-airplanes-live-client-side.md
@@ -1,0 +1,91 @@
+# ADR 0007 — Aircraft layer fetches airplanes.live directly from the browser
+
+- **Status:** Accepted
+- **Date:** 2026-06-24
+
+## Context
+
+The aircraft/helicopter layer (PRD #165) adds live aircraft as Vehicles on the
+map. That data has to come from a real-time ADS-B source, fetched **directly
+from the browser** — the app is a client-only SPA with no backend and no proxy
+([ADR 0001](0001-cookieless-no-consent-popup.md)). A source therefore has to be
+reachable from the browser with no auth secret and with permissive CORS.
+
+The candidates evaluated:
+
+- **airplanes.live** — unauthenticated REST API, sends
+  `access-control-allow-origin: *`, so it works directly from the browser with
+  no proxy and no key. Point endpoint:
+  `GET https://api.airplanes.live/v2/point/{lat}/{lon}/{radius_nm}` (radius
+  ≤ 250 nm). Rate-limited to **1 request/second**. Terms are **Non-Commercial
+  Use** with **no SLA**.
+- **adsb.lol** — comparable data, but does **not** send the CORS header, so a
+  browser fetch is blocked; it would require a proxy (a backend), which the
+  architecture does not have.
+- **OpenSky Network** — requires an **OAuth client secret**. A secret cannot
+  live in a client SPA (it would be world-readable in the bundle), so it is
+  incompatible with the no-backend constraint.
+
+airplanes.live is the only candidate that fits the client-only, no-proxy
+architecture.
+
+## Decision
+
+The aircraft layer fetches **airplanes.live** directly from the browser, with no
+proxy and no auth, under its **Non-Commercial Use / no-SLA** terms. The endpoint
+is declared in the single external-URL source of truth
+(`src/config/endpoints.js`, `AIRPLANES_LIVE_BASE`).
+
+airplanes.live is **disclosed in the Privacy Notice** alongside Trafiklab,
+OpenStreetMap, and the webcam sources — named, linked, and annotated that the
+data is fetched **only while zoomed in**. **No Consent surface is introduced**:
+this is the same trust category as the existing third-party fetches (Trafiklab
+API, OSM/CARTO tiles, hotlinked webcam stills) — the network request inherently
+exposes the user's IP to the source, but nothing is stored on the device and no
+source-controlled script runs. ADR 0001's cookieless posture is therefore
+**unaffected**.
+
+## Rationale
+
+- **Fits the architecture.** Unauthenticated + CORS-open is the only shape a
+  browser can fetch without a proxy; the alternatives need a backend (adsb.lol)
+  or a secret that cannot ship in client code (OpenSky).
+- **Keeps ADR 0001 standing.** No new client storage, no embedded
+  source-controlled script, no identifying data shared beyond what the request
+  inherently exposes — none of ADR 0001's reversal triggers fire, so the
+  Privacy Notice (not a Consent gate) remains the correct surface.
+- **Proportionate to a private demo.** The Non-Commercial-Use terms and absence
+  of an SLA are acceptable because this is a **private, non-monetized demo**.
+  Aircraft are non-essential overlay data: a fetch failure simply means no
+  aircraft show, with no error surfaced.
+
+## Trade-offs
+
+- **Non-Commercial Use only.** If the project is ever monetized or shipped
+  commercially, this source's terms no longer permit it and the source must be
+  swapped (see reversal trigger).
+- **No SLA.** airplanes.live may be slow or unavailable; the layer tolerates
+  this silently (aircraft are an overlay, not core transit data).
+- **1 req/s budget.** The aircraft poll fetches only when zoomed in (≈ zoom 8+)
+  and derives a viewport-capped radius (≤ 250 nm) to stay within budget.
+
+## Reversal trigger
+
+This decision is revisited if **any** of the following holds:
+
+- The project becomes **commercial / monetized** — Non-Commercial Use no longer
+  applies and the source must be replaced with a commercially-licensed one.
+- A future aircraft feature requires **auth, a secret, or any persisted or
+  identifying data sent to the source** beyond the coordinates of a public
+  ADS-B query — that would trip ADR 0001's reversal trigger and oblige the full
+  Consent surface ADR 0001 prescribes.
+
+## Related
+
+- [ADR 0001](0001-cookieless-no-consent-popup.md) — cookieless app, Privacy
+  Notice not Consent gate; defines the reversal trigger this ADR stays inside.
+- [ADR 0004](0004-webcam-layer-static-images-no-embeds.md) — third-party-source
+  precedent (hotlinked stills in the same trust category).
+- [CONTEXT.md](../../CONTEXT.md) — **Aircraft** / **Vehicle**, **Transport
+  modes** (mode set decoupled from GTFS), and the **Privacy Notice** glossary.
+- Parent PRD: `#165` — Aircraft/helicopter layer + click-to-follow vehicles.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { useConnectivity } from './hooks/useConnectivity';
 import { useGeolocation } from './hooks/useGeolocation';
 import { useUpdatePrompt } from './hooks/useUpdatePrompt';
 import { useWebcams } from './hooks/useWebcams';
+import { useAircraft } from './hooks/useAircraft';
 import {
   CAMERA_TYPE_DEFINITIONS,
   cameraCountsByType,
@@ -62,6 +63,20 @@ function App() {
   const { vehicles: allVehicles, feedOutcomes, error, loading, lastUpdate, refresh, activeOperators, effectiveInterval } =
     useRealtimeVehicles(visibleOperators, 2000, isOnline);
 
+  // Aircraft come from airplanes.live, polled around the current viewport centre.
+  // They are merged into the map's Vehicle list ONLY — the Command Center keeps
+  // receiving transit Vehicles, so aircraft never enter its anomaly/feed pipeline.
+  const aircraftCenter = useMemo(
+    () => ({ lat: mapCenter[0], lon: mapCenter[1] }),
+    [mapCenter],
+  );
+  const { aircraft } = useAircraft(aircraftCenter, isOnline);
+
+  const mapVehicles = useMemo(
+    () => [...allVehicles, ...aircraft],
+    [allVehicles, aircraft],
+  );
+
   const {
     enabledModes,
     toggleMode,
@@ -74,7 +89,7 @@ function App() {
     clearFavourites,
     availableLines,
     filteredVehicles,
-  } = useFilterSelection(allVehicles);
+  } = useFilterSelection(mapVehicles);
 
   const handleCameraTypeToggle = (typeId) => {
     setEnabledCameraTypes(prev =>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { useConnectivity } from './hooks/useConnectivity';
 import { useGeolocation } from './hooks/useGeolocation';
 import { useUpdatePrompt } from './hooks/useUpdatePrompt';
 import { useWebcams } from './hooks/useWebcams';
+import { useAircraft } from './hooks/useAircraft';
 import {
   CAMERA_TYPE_DEFINITIONS,
   cameraCountsByType,
@@ -62,6 +63,20 @@ function App() {
   const { vehicles: allVehicles, feedOutcomes, error, loading, lastUpdate, refresh, activeOperators, effectiveInterval } =
     useRealtimeVehicles(visibleOperators, 2000, isOnline);
 
+  // Live aircraft overlay (PRD #165). Fetched on a fixed ~2 s cadence around the
+  // current viewport centre with a sane default radius (the zoom gate and
+  // viewport-radius derivation are a follow-up slice). Merged into the map's
+  // Vehicle list below — but deliberately kept OUT of the Command Center, which
+  // only ever sees transit Vehicles.
+  const aircraftQuery = useMemo(
+    () => ({ lat: mapCenter[0], lon: mapCenter[1], radius: 100 }),
+    [mapCenter],
+  );
+  const { aircraft } = useAircraft(aircraftQuery, { enabled: isOnline });
+
+  // Map Vehicle list = transit Vehicles ⧺ aircraft Vehicles.
+  const mapVehicles = useMemo(() => [...allVehicles, ...aircraft], [allVehicles, aircraft]);
+
   const {
     enabledModes,
     toggleMode,
@@ -74,7 +89,7 @@ function App() {
     clearFavourites,
     availableLines,
     filteredVehicles,
-  } = useFilterSelection(allVehicles);
+  } = useFilterSelection(mapVehicles);
 
   const handleCameraTypeToggle = (typeId) => {
     setEnabledCameraTypes(prev =>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import { useGeolocation } from './hooks/useGeolocation';
 import { useUpdatePrompt } from './hooks/useUpdatePrompt';
 import { useWebcams } from './hooks/useWebcams';
 import { useAircraft } from './hooks/useAircraft';
+import { deriveAircraftQuery } from './services/aircraft';
 import {
   CAMERA_TYPE_DEFINITIONS,
   cameraCountsByType,
@@ -63,14 +64,16 @@ function App() {
   const { vehicles: allVehicles, feedOutcomes, error, loading, lastUpdate, refresh, activeOperators, effectiveInterval } =
     useRealtimeVehicles(visibleOperators, 2000, isOnline);
 
-  // Live aircraft overlay (PRD #165). Fetched on a fixed ~2 s cadence around the
-  // current viewport centre with a sane default radius (the zoom gate and
-  // viewport-radius derivation are a follow-up slice). Merged into the map's
-  // Vehicle list below — but deliberately kept OUT of the Command Center, which
-  // only ever sees transit Vehicles.
+  // Live aircraft overlay (PRD #165). Zoom-gated and viewport-bounded: below
+  // AIRCRAFT_MIN_ZOOM the query is null, so the hook issues no request at all and
+  // shows no aircraft (protecting the 1 req/s budget at country view). At/above
+  // it, the query centre/radius derive from the current viewport bounds, capped
+  // at 250 nm. Polled on a fixed ~2 s cadence; merged into the map's Vehicle list
+  // below — but deliberately kept OUT of the Command Center, which only ever sees
+  // transit Vehicles.
   const aircraftQuery = useMemo(
-    () => ({ lat: mapCenter[0], lon: mapCenter[1], radius: 100 }),
-    [mapCenter],
+    () => deriveAircraftQuery(viewportBounds, mapZoom),
+    [viewportBounds, mapZoom],
   );
   const { aircraft } = useAircraft(aircraftQuery, { enabled: isOnline });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -121,12 +121,14 @@ function App() {
   } = useFilterSelection(mapVehicles);
 
   // Resolve the followed Vehicle's live position (for the map's panTo seam) and
-  // detect feed-exit. Tracks the full feed (allVehicles), not the mode/line
-  // filtered list, so a deliberately-followed Vehicle is not lost to a filter.
-  // onExit fires once when the followed Vehicle leaves the feed — follow ends
-  // silently (selection cleared, no error surfaced; story 17).
+  // detect feed-exit. Tracks the full UNFILTERED merged list (mapVehicles =
+  // transit ⧺ aircraft), not the mode/line-filtered list — so a deliberately
+  // followed Vehicle is not lost to a filter, AND a followed Aircraft (which
+  // lives only in mapVehicles, not allVehicles) actually pans and exits (story
+  // 18). onExit fires once when the followed Vehicle leaves the feed — follow
+  // ends silently (selection cleared, no error surfaced; story 17).
   const { followedPosition } = useFollowVehicle({
-    vehicles: allVehicles,
+    vehicles: mapVehicles,
     selectedVehicleId,
     followMode,
     onExit: stopFollowing,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,9 +92,14 @@ function App() {
   // at 250 nm. Polled on a fixed ~2 s cadence; merged into the map's Vehicle list
   // below — but deliberately kept OUT of the Command Center, which only ever sees
   // transit Vehicles.
+  // Gate on the LIVE viewport zoom (reported with the bounds on zoomend), not
+  // the programmatic flyTo target (mapZoom): mapZoom only changes on geolocation
+  // / region-select, so gating on it left aircraft fetching at country view
+  // after a user zoomed out via the map controls — defeating the zoom gate and
+  // the 1 req/s budget (PRD #165, slice 2).
   const aircraftQuery = useMemo(
-    () => deriveAircraftQuery(viewportBounds, mapZoom),
-    [viewportBounds, mapZoom],
+    () => deriveAircraftQuery(viewportBounds, viewportBounds?.zoom),
+    [viewportBounds],
   );
   const { aircraft } = useAircraft(aircraftQuery, { enabled: isOnline });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { useConnectivity } from './hooks/useConnectivity';
 import { useGeolocation } from './hooks/useGeolocation';
 import { useUpdatePrompt } from './hooks/useUpdatePrompt';
 import { useWebcams } from './hooks/useWebcams';
+import { useFollowVehicle } from './hooks/useFollowVehicle';
 import {
   CAMERA_TYPE_DEFINITIONS,
   cameraCountsByType,
@@ -36,6 +37,26 @@ function App() {
   const [enabledCameraTypes, setEnabledCameraTypes] = useState(
     CAMERA_TYPE_DEFINITIONS.map(t => t.id),
   );
+  // Followed vehicle (PRD #165, issue #167): a session-only singleton — a single
+  // selected id + follow flag, held in memory only and forgotten on reload. It
+  // is orthogonal to the Command-Center selection/highlight.
+  const [selectedVehicleId, setSelectedVehicleId] = useState(null);
+  const [followMode, setFollowMode] = useState(false);
+
+  const stopFollowing = () => {
+    setFollowMode(false);
+    setSelectedVehicleId(null);
+  };
+
+  // Popup Follow/Stop toggle: follow the clicked Vehicle, or stop if it is the
+  // one already being followed.
+  const handleFollowToggle = (vehicleId) => {
+    setSelectedVehicleId((currentId) => {
+      const alreadyFollowing = followMode && currentId === vehicleId;
+      setFollowMode(!alreadyFollowing);
+      return alreadyFollowing ? null : vehicleId;
+    });
+  };
 
   // Fly to the User location when a fix arrives, at city-level zoom (~12).
   // This reuses the existing center/zoom → Map flyTo seam; moving the viewport
@@ -75,6 +96,23 @@ function App() {
     availableLines,
     filteredVehicles,
   } = useFilterSelection(allVehicles);
+
+  // Resolve the followed Vehicle's live position (for the map's panTo seam) and
+  // detect feed-exit. Tracks the full feed (allVehicles), not the mode/line
+  // filtered list, so a deliberately-followed Vehicle is not lost to a filter.
+  // onExit fires once when the followed Vehicle leaves the feed — follow ends
+  // silently (selection cleared, no error surfaced; story 17).
+  const { followedPosition } = useFollowVehicle({
+    vehicles: allVehicles,
+    selectedVehicleId,
+    followMode,
+    onExit: stopFollowing,
+  });
+
+  const followedVehicleIds = useMemo(
+    () => (followMode && selectedVehicleId ? [selectedVehicleId] : []),
+    [followMode, selectedVehicleId],
+  );
 
   const handleCameraTypeToggle = (typeId) => {
     setEnabledCameraTypes(prev =>
@@ -133,6 +171,10 @@ function App() {
         onBoundsChange={setViewportBounds}
         theme={theme}
         userLocation={userLocation}
+        followedVehicleIds={followedVehicleIds}
+        onFollowToggle={handleFollowToggle}
+        followPosition={followedPosition}
+        onMapClick={stopFollowing}
       />
       <PanelComponent
         vehicles={filteredVehicles}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -10,6 +10,8 @@ import { createVehicleAdapter, FULL_MARKER_MIN_ZOOM } from '../services/vehicleA
 import { createWebcamAdapter } from '../services/webcamAdapter';
 
 const EMPTY_HIGHLIGHTED_VEHICLE_IDS = [];
+const EMPTY_FOLLOWED_VEHICLE_IDS = [];
+const NOOP = () => {};
 
 function haveSameOrderedIds(previousIds, nextIds) {
   if (previousIds.length !== nextIds.length) return false;
@@ -28,7 +30,7 @@ function createHighlightState(highlightedVehicleIds) {
   };
 }
 
-export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = EMPTY_HIGHLIGHTED_VEHICLE_IDS, userLocation = null }) {
+export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = EMPTY_HIGHLIGHTED_VEHICLE_IDS, userLocation = null, followedVehicleIds = EMPTY_FOLLOWED_VEHICLE_IDS, onFollowToggle = NOOP, followPosition = null, onMapClick = NOOP }) {
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
   // Singleton User location marker (PRD #111). A single circle marker managed
@@ -39,6 +41,15 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   // Highlight set is read live by the adapter so selection changes are reflected.
   const [initialHighlightState] = useState(() => createHighlightState(highlightedVehicleIds));
   const highlightStateRef = useRef(initialHighlightState);
+  // Follow set (the single Followed vehicle, issue #167), read live by the
+  // adapter parallel to the highlight set. Follow composes with highlight, so
+  // it is a separate set rather than sharing the highlight one.
+  const [initialFollowState] = useState(() => createHighlightState(followedVehicleIds));
+  const followStateRef = useRef(initialFollowState);
+  // onFollowToggle is read live by the adapter via this ref so a popup Follow
+  // click always reaches the current handler without rebuilding the adapter.
+  const onFollowToggleRef = useRef(onFollowToggle);
+  onFollowToggleRef.current = onFollowToggle;
   // Current zoom, read live by the adapter; mapZoom state re-triggers the
   // marker-update effect so existing markers swap compact/full icons on zoom.
   const zoomRef = useRef(zoom);
@@ -46,9 +57,15 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   const vehicleAdapterRef = useRef(
     createVehicleAdapter({
       isHighlighted: (id) => highlightStateRef.current.idSet.has(id),
+      isFollowed: (id) => followStateRef.current.idSet.has(id),
+      onFollowToggle: (id) => onFollowToggleRef.current(id),
       getZoom: () => zoomRef.current,
     }),
   );
+  // onMapClick (stop-following on empty-map click) read live so the handler
+  // bound once on the map always calls the current prop.
+  const onMapClickRef = useRef(onMapClick);
+  onMapClickRef.current = onMapClick;
   const webcamCollectionRef = useRef(null);
   const webcamAdapterRef = useRef(createWebcamAdapter());
   const markerLayerRef = useRef(null);
@@ -113,6 +130,11 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
         }, 300);
       };
 
+      // Clicking the empty map background (not a marker) stops following
+      // (issue #167, story 16). Leaflet's map 'click' only fires for the base
+      // map, not for marker clicks, so this never fires when opening a popup.
+      map.on('click', () => onMapClickRef.current());
+
       map.on('moveend', reportBounds);
       map.on('zoomend', reportBounds);
       map.on('zoomend', () => {
@@ -150,6 +172,15 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
     }
   }, [center, zoom]);
 
+  // Follow pan (issue #167): while following, pan to the followed Vehicle's
+  // latest position on every update — a smooth panTo that KEEPS the user's
+  // current zoom, deliberately not the 1s re-zooming flyTo used for jumps.
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map || !followPosition) return;
+    map.panTo(followPosition);
+  }, [followPosition]);
+
   // Update vehicle markers via the marker-collection module. Runs after render
   // so highlight bookkeeping stays out of render; the equality gate prevents
   // marker churn unless vehicles, ordered highlights, or zoom actually changed.
@@ -161,9 +192,16 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
       highlightState.idSet = new Set(highlightedVehicleIds);
     }
 
+    const followState = followStateRef.current;
+    const followChanged = !haveSameOrderedIds(followState.ids, followedVehicleIds);
+    if (followChanged) {
+      followState.ids = followedVehicleIds.slice();
+      followState.idSet = new Set(followedVehicleIds);
+    }
+
     const vehiclesChanged = highlightState.vehicles !== vehicles;
     const zoomChanged = highlightState.mapZoom !== mapZoom;
-    if (!vehiclesChanged && !highlightsChanged && !zoomChanged) return;
+    if (!vehiclesChanged && !highlightsChanged && !followChanged && !zoomChanged) return;
 
     highlightState.vehicles = vehicles;
     highlightState.mapZoom = mapZoom;

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -147,6 +147,7 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
             onBoundsChangeRef.current({
               south: b.getSouth(), west: b.getWest(),
               north: b.getNorth(), east: b.getEast(),
+              zoom: map.getZoom(),
             });
           }
         }, 300);

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -36,6 +36,15 @@ function createHighlightState(highlightedVehicleIds) {
   };
 }
 
+// Refresh a keyed id-set state in place when the ordered ids changed; returns
+// whether it changed so the caller can gate marker churn.
+function updateIdSet(state, nextIds) {
+  if (haveSameOrderedIds(state.ids, nextIds)) return false;
+  state.ids = nextIds.slice();
+  state.idSet = new Set(nextIds);
+  return true;
+}
+
 export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], zoom = 11, onBoundsChange = null, theme = 'light', highlightedVehicleIds = EMPTY_VEHICLE_IDS, predictedVehicleIds = EMPTY_VEHICLE_IDS, userLocation = null, followedVehicleIds = EMPTY_FOLLOWED_VEHICLE_IDS, onFollowToggle = NOOP, followPosition = null, onMapClick = NOOP }) {
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
@@ -56,7 +65,7 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   // Follow set (the single Followed vehicle, issue #167), read live by the
   // adapter parallel to the highlight set. Follow composes with highlight, so
   // it is a separate set rather than sharing the highlight one.
-  const [initialFollowState] = useState(() => createHighlightState(followedVehicleIds));
+  const [initialFollowState] = useState(() => createIdSetState(followedVehicleIds));
   const followStateRef = useRef(initialFollowState);
   // onFollowToggle is read live by the adapter via this ref so a popup Follow
   // click always reaches the current handler without rebuilding the adapter.
@@ -200,25 +209,9 @@ export function Map({ vehicles = [], cameras = [], center = [59.3293, 18.0686], 
   // (Downstream) set, or zoom actually changed.
   useEffect(() => {
     const highlightState = highlightStateRef.current;
-    const highlightsChanged = !haveSameOrderedIds(highlightState.ids, highlightedVehicleIds);
-    if (highlightsChanged) {
-      highlightState.ids = highlightedVehicleIds.slice();
-      highlightState.idSet = new Set(highlightedVehicleIds);
-    }
-
-    const predictedState = predictedStateRef.current;
-    const predictedChanged = !haveSameOrderedIds(predictedState.ids, predictedVehicleIds);
-    if (predictedChanged) {
-      predictedState.ids = predictedVehicleIds.slice();
-      predictedState.idSet = new Set(predictedVehicleIds);
-    }
-
-    const followState = followStateRef.current;
-    const followChanged = !haveSameOrderedIds(followState.ids, followedVehicleIds);
-    if (followChanged) {
-      followState.ids = followedVehicleIds.slice();
-      followState.idSet = new Set(followedVehicleIds);
-    }
+    const highlightsChanged = updateIdSet(highlightState, highlightedVehicleIds);
+    const predictedChanged = updateIdSet(predictedStateRef.current, predictedVehicleIds);
+    const followChanged = updateIdSet(followStateRef.current, followedVehicleIds);
 
     const vehiclesChanged = highlightState.vehicles !== vehicles;
     const zoomChanged = highlightState.mapZoom !== mapZoom;

--- a/src/components/PrivacyNotice.jsx
+++ b/src/components/PrivacyNotice.jsx
@@ -47,7 +47,16 @@ export function PrivacyNotice() {
             Windy
           </a>{' '}
           and a curated webcam catalogue (camera listings and links only — no
-          media is fetched from them). This site stores no tracking cookies.
+          media is fetched from them). Aircraft data:{' '}
+          <a
+            href="https://airplanes.live/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            airplanes.live
+          </a>{' '}
+          (Non-Commercial Use, no SLA; fetched only while zoomed in). This site
+          stores no tracking cookies.
         </p>
         <button
           type="button"

--- a/src/components/PrivacyNotice.test.jsx
+++ b/src/components/PrivacyNotice.test.jsx
@@ -27,10 +27,32 @@ describe('PrivacyNotice', () => {
     expect(screen.getByText(/curated webcam catalogue/i)).toBeTruthy();
   });
 
-  it('reappears for users who acknowledged an older notice version (re-disclosure)', () => {
-    window.localStorage.setItem('rtt-privacy-notice-v2', '1');
+  it('names airplanes.live as the aircraft data source, linked, fetched only when zoomed in', () => {
     render(<PrivacyNotice />);
 
-    expect(screen.getByText(/Windy/i)).toBeTruthy();
+    const link = screen.getByRole('link', { name: /airplanes\.live/i });
+    expect(link.getAttribute('href')).toMatch(/airplanes\.live/i);
+    expect(screen.getByText(/zoomed in/i)).toBeTruthy();
+  });
+
+  it('still states the site stores no tracking cookies (cookieless claim holds)', () => {
+    render(<PrivacyNotice />);
+
+    expect(screen.getByText(/stores no tracking cookies/i)).toBeTruthy();
+  });
+
+  it('introduces no Accept/Reject Consent surface — only an acknowledgement', () => {
+    render(<PrivacyNotice />);
+
+    expect(screen.queryByRole('button', { name: /accept/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /reject/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /got it/i })).toBeTruthy();
+  });
+
+  it('reappears for users who acknowledged an older notice version (re-disclosure)', () => {
+    window.localStorage.setItem('rtt-privacy-notice-v3', '1');
+    render(<PrivacyNotice />);
+
+    expect(screen.getByText(/airplanes\.live/i)).toBeTruthy();
   });
 });

--- a/src/config/endpoints.js
+++ b/src/config/endpoints.js
@@ -6,6 +6,11 @@ export const TRAFIKLAB_FEED_BASE = 'https://opendata.samtrafiken.se/gtfs-rt-swed
 
 export const TRIP_MAPPING_URL = '/data/trip-mapping.json';
 
+// airplanes.live — unauthenticated, CORS-open (access-control-allow-origin: *),
+// so it is fetched directly from the browser with no proxy (ADR 0001 intact).
+// Point endpoint: `${base}/point/{lat}/{lon}/{radius_nm}` (radius ≤ 250 nm).
+export const AIRPLANES_LIVE_BASE = 'https://api.airplanes.live/v2';
+
 export const LIGHT_TILES = {
   urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   attribution:

--- a/src/config/endpoints.js
+++ b/src/config/endpoints.js
@@ -6,6 +6,11 @@ export const TRAFIKLAB_FEED_BASE = 'https://opendata.samtrafiken.se/gtfs-rt-swed
 
 export const TRIP_MAPPING_URL = '/data/trip-mapping.json';
 
+// airplanes.live — unauthenticated, CORS-open (access-control-allow-origin: *),
+// so it is reachable directly from the browser with no proxy/backend (ADR 0001).
+// Point query: GET /v2/point/{lat}/{lon}/{radius_nm}; radius capped at 250 nm.
+export const AIRPLANES_LIVE_BASE = 'https://api.airplanes.live/v2';
+
 export const LIGHT_TILES = {
   urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   attribution:

--- a/src/config/endpoints.js
+++ b/src/config/endpoints.js
@@ -6,6 +6,12 @@ export const TRAFIKLAB_FEED_BASE = 'https://opendata.samtrafiken.se/gtfs-rt-swed
 
 export const TRIP_MAPPING_URL = '/data/trip-mapping.json';
 
+// Aircraft data: airplanes.live — unauthenticated and CORS-open, fetched
+// directly from the browser with no proxy, under Non-Commercial Use / no SLA.
+// Disclosed in the Privacy Notice; chosen and licence-framed in ADR 0007
+// (docs/adr/0007-aircraft-airplanes-live-client-side.md). The point-endpoint
+// constant is declared by the aircraft-fetch slice.
+
 export const LIGHT_TILES = {
   urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   attribution:

--- a/src/hooks/useAircraft.js
+++ b/src/hooks/useAircraft.js
@@ -39,10 +39,16 @@ export function useAircraft(query, { enabled = true, intervalMs = 2000 } = {}) {
       return;
     }
 
+    // Per-effect guard: a fetch in flight when the query changes (pan/zoom) or
+    // the hook unmounts must not apply its now-stale result over the fresh
+    // viewport's aircraft. Set in this effect's cleanup, so each query owns its
+    // own flag (aliveRef alone only covers unmount, not query changes).
+    let cancelled = false;
+
     const fetchData = async () => {
       try {
         const next = await fetchAircraft(query);
-        if (aliveRef.current) setAircraft(next);
+        if (!cancelled && aliveRef.current) setAircraft(next);
       } catch {
         // Non-essential overlay: swallow failures, keep the last good list.
       }
@@ -75,6 +81,7 @@ export function useAircraft(query, { enabled = true, intervalMs = 2000 } = {}) {
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
+      cancelled = true;
       stopPolling();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };

--- a/src/hooks/useAircraft.js
+++ b/src/hooks/useAircraft.js
@@ -1,0 +1,85 @@
+import { useState, useEffect, useRef } from 'react';
+import { fetchAircraft } from '../services/aircraft';
+
+/**
+ * Poll live aircraft around a viewport point and expose them as Vehicles.
+ *
+ * Separate from the transit polling hook because the transit poll interval
+ * scales with the number of watched operators (and would leave aircraft stale)
+ * and because an airplanes.live failure must never enter the transit
+ * feedOutcomes. The hook polls on a fixed ~2 s cadence, pauses on tab-hidden
+ * (same discipline as the transit hook), and tolerates fetch/parse failure
+ * silently — aircraft are non-essential overlay data, so they simply don't
+ * appear and no error is surfaced (PRD #165).
+ *
+ * The zoom gate and viewport-radius derivation are a follow-up slice; here the
+ * caller passes the query (or null to fetch nothing).
+ *
+ * @param {{ lat: number, lon: number, radius: number } | null} query
+ * @param {{ enabled?: boolean, intervalMs?: number }} [opts]
+ * @returns {{ aircraft: object[] }}
+ */
+export function useAircraft(query, { enabled = true, intervalMs = 2000 } = {}) {
+  const [aircraft, setAircraft] = useState([]);
+  const intervalRef = useRef(null);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => { aliveRef.current = false; };
+  }, []);
+
+  // Serialise the query so the polling effect only re-subscribes when the
+  // viewport actually moves, not on every render.
+  const queryKey = query ? `${query.lat},${query.lon},${query.radius}` : null;
+
+  useEffect(() => {
+    if (!enabled || !query) {
+      setAircraft([]);
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        const next = await fetchAircraft(query);
+        if (aliveRef.current) setAircraft(next);
+      } catch {
+        // Non-essential overlay: swallow failures, keep the last good list.
+      }
+    };
+
+    const startPolling = () => {
+      if (!intervalRef.current) {
+        intervalRef.current = setInterval(fetchData, intervalMs);
+      }
+    };
+
+    const stopPolling = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        fetchData();
+        startPolling();
+      }
+    };
+
+    fetchData();
+    startPolling();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      stopPolling();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, queryKey, intervalMs]);
+
+  return { aircraft };
+}

--- a/src/hooks/useAircraft.js
+++ b/src/hooks/useAircraft.js
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react';
+import { fetchAircraft } from '../services/aircraft';
+
+// Aircraft are non-essential overlay data fetched on a fixed ~2 s cadence,
+// separate from the transit poll: the transit interval scales with the number
+// of watched operators (up to ~30 s) and would leave aircraft stale, and an
+// airplanes.live failure must never enter the transit feedOutcomes.
+const AIRCRAFT_POLL_INTERVAL = 2000;
+
+// This slice fetches the viewport centre with a fixed default radius; the zoom
+// gate and viewport-derived radius are deferred to the follow-up slice.
+const DEFAULT_RADIUS_NM = 100;
+
+/**
+ * Poll airplanes.live for aircraft around a centre point.
+ *
+ * @param {{ lat: number, lon: number } | null} center
+ * @param {boolean} enabled
+ * @returns {{ aircraft: object[] }}
+ */
+export function useAircraft(center, enabled = true) {
+  const [aircraft, setAircraft] = useState([]);
+  const aliveRef = useRef(true);
+  const intervalRef = useRef(null);
+  // Hold the latest centre in a ref so a centre change does not restart the
+  // poll loop; each tick reads the current value.
+  const centerRef = useRef(center);
+  centerRef.current = center;
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => { aliveRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setAircraft([]);
+      return undefined;
+    }
+
+    const poll = async () => {
+      const c = centerRef.current;
+      if (!c) return;
+      try {
+        const next = await fetchAircraft({ lat: c.lat, lon: c.lon, radius: DEFAULT_RADIUS_NM });
+        if (aliveRef.current) setAircraft(next);
+      } catch {
+        // Silent: aircraft are non-essential overlay data. They simply don't
+        // show; transit Vehicles are unaffected and no error is surfaced.
+      }
+    };
+
+    const startPolling = () => {
+      if (!intervalRef.current) {
+        intervalRef.current = setInterval(poll, AIRCRAFT_POLL_INTERVAL);
+      }
+    };
+
+    const stopPolling = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        poll();
+        startPolling();
+      }
+    };
+
+    poll();
+    startPolling();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      stopPolling();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [enabled]);
+
+  return { aircraft };
+}

--- a/src/hooks/useAircraft.test.js
+++ b/src/hooks/useAircraft.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAircraft } from './useAircraft';
+import * as service from '../services/aircraft';
+
+const SAMPLE = [
+  { id: 'air:abc', line: 'SAS123', mode: 'aircraft', latitude: 59.3, longitude: 18.0 },
+];
+const QUERY = { lat: 59.3, lon: 18.0, radius: 100 };
+
+describe('useAircraft', () => {
+  beforeEach(() => {
+    vi.spyOn(service, 'fetchAircraft').mockResolvedValue(SAMPLE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('fetches on mount and exposes the mapped aircraft', async () => {
+    const { result } = renderHook(() => useAircraft(QUERY, { enabled: true }));
+    await waitFor(() => expect(result.current.aircraft).toEqual(SAMPLE));
+    expect(service.fetchAircraft).toHaveBeenCalled();
+    expect(service.fetchAircraft.mock.calls[0][0]).toEqual(QUERY);
+  });
+
+  it('does not fetch when disabled', () => {
+    renderHook(() => useAircraft(QUERY, { enabled: false }));
+    expect(service.fetchAircraft).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when there is no query', () => {
+    renderHook(() => useAircraft(null, { enabled: true }));
+    expect(service.fetchAircraft).not.toHaveBeenCalled();
+  });
+
+  it('polls on the configured cadence', async () => {
+    vi.useFakeTimers();
+    renderHook(() => useAircraft(QUERY, { enabled: true, intervalMs: 2000 }));
+    await vi.waitFor(() => expect(service.fetchAircraft).toHaveBeenCalledTimes(1));
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+    expect(service.fetchAircraft).toHaveBeenCalledTimes(2);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+    expect(service.fetchAircraft).toHaveBeenCalledTimes(3);
+  });
+
+  it('tolerates a rejected fetch silently — aircraft stays empty, no throw', async () => {
+    service.fetchAircraft.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useAircraft(QUERY, { enabled: true }));
+    await new Promise(r => setTimeout(r, 10));
+    expect(result.current.aircraft).toEqual([]);
+  });
+
+  it('does not throw when a poll resolves after unmount', async () => {
+    let resolvePending;
+    service.fetchAircraft.mockImplementationOnce(
+      () => new Promise(r => { resolvePending = r; }),
+    );
+    const { unmount } = renderHook(() => useAircraft(QUERY, { enabled: true }));
+    unmount();
+    resolvePending(SAMPLE);
+    await new Promise(r => setTimeout(r, 10));
+  });
+});

--- a/src/hooks/useAircraft.test.js
+++ b/src/hooks/useAircraft.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useAircraft } from './useAircraft';
+import * as service from '../services/aircraft';
+
+const SAMPLE = [
+  { id: 'air:abc', mode: 'aircraft', line: 'SAS123', latitude: 59.3, longitude: 18.0 },
+];
+
+const CENTER = { lat: 59.33, lon: 18.07 };
+
+describe('useAircraft', () => {
+  beforeEach(() => {
+    vi.spyOn(service, 'fetchAircraft').mockResolvedValue(SAMPLE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('does not fetch while disabled', () => {
+    renderHook(() => useAircraft(CENTER, false));
+    expect(service.fetchAircraft).not.toHaveBeenCalled();
+  });
+
+  it('disabled hook exposes an empty aircraft list', () => {
+    const { result } = renderHook(() => useAircraft(CENTER, false));
+    expect(result.current.aircraft).toEqual([]);
+  });
+
+  it('fetches the viewport centre on enable and exposes the aircraft', async () => {
+    const { result } = renderHook(() => useAircraft(CENTER, true));
+    await waitFor(() => expect(result.current.aircraft).toEqual(SAMPLE));
+    expect(service.fetchAircraft).toHaveBeenCalledWith(
+      expect.objectContaining({ lat: 59.33, lon: 18.07 }),
+    );
+  });
+
+  it('polls on a fixed ~2s cadence', async () => {
+    vi.useFakeTimers();
+    renderHook(() => useAircraft(CENTER, true));
+    // Initial immediate fetch.
+    await vi.waitFor(() => expect(service.fetchAircraft).toHaveBeenCalledTimes(1));
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+    expect(service.fetchAircraft).toHaveBeenCalledTimes(2);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+    expect(service.fetchAircraft).toHaveBeenCalledTimes(3);
+  });
+
+  it('pauses polling while the tab is hidden and resumes when visible', async () => {
+    vi.useFakeTimers();
+    renderHook(() => useAircraft(CENTER, true));
+    await vi.waitFor(() => expect(service.fetchAircraft).toHaveBeenCalledTimes(1));
+
+    // Hide the tab — polling stops.
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+
+    const callsWhenHidden = service.fetchAircraft.mock.calls.length;
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000); });
+    expect(service.fetchAircraft).toHaveBeenCalledTimes(callsWhenHidden);
+
+    // Show the tab — an immediate fetch resumes.
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+    expect(service.fetchAircraft.mock.calls.length).toBeGreaterThan(callsWhenHidden);
+  });
+
+  it('tolerates a rejected fetch silently — aircraft stay empty, no throw', async () => {
+    service.fetchAircraft.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useAircraft(CENTER, true));
+    // Give the rejected fetch a chance to settle.
+    await new Promise(r => setTimeout(r, 10));
+    expect(result.current.aircraft).toEqual([]);
+  });
+
+  it('does not throw when a fetch resolves after unmount', async () => {
+    let resolvePending;
+    service.fetchAircraft.mockImplementationOnce(
+      () => new Promise(r => { resolvePending = r; }),
+    );
+    const { unmount } = renderHook(() => useAircraft(CENTER, true));
+    unmount();
+    resolvePending(SAMPLE);
+    await new Promise(r => setTimeout(r, 10));
+  });
+});

--- a/src/hooks/useAircraft.test.js
+++ b/src/hooks/useAircraft.test.js
@@ -65,6 +65,29 @@ describe('useAircraft', () => {
     resolvePending(SAMPLE);
     await new Promise(r => setTimeout(r, 10));
   });
+
+  it('ignores a fetch that resolves after the query changed (no stale viewport aircraft)', async () => {
+    const FRESH = [{ id: 'air:fresh', mode: 'aircraft', latitude: 2, longitude: 2 }];
+    const STALE = [{ id: 'air:stale', mode: 'aircraft', latitude: 1, longitude: 1 }];
+    let resolveStale;
+    // Query A's fetch hangs; once the query changes, B resolves FRESH.
+    service.fetchAircraft.mockImplementationOnce(
+      () => new Promise(r => { resolveStale = r; }),
+    );
+    service.fetchAircraft.mockResolvedValue(FRESH);
+
+    const { result, rerender } = renderHook(
+      ({ q }) => useAircraft(q, { enabled: true }),
+      { initialProps: { q: { lat: 1, lon: 1, radius: 10 } } },
+    );
+    rerender({ q: { lat: 2, lon: 2, radius: 10 } }); // supersedes query A
+    await waitFor(() => expect(result.current.aircraft).toEqual(FRESH));
+
+    // Query A's late result must not clobber the current viewport's aircraft.
+    await act(async () => { resolveStale(STALE); });
+    await new Promise(r => setTimeout(r, 10));
+    expect(result.current.aircraft).toEqual(FRESH);
+  });
 });
 
 // Zoom gate + viewport-radius derivation (PRD #165, Slice 2). These drive the

--- a/src/hooks/useAircraft.test.js
+++ b/src/hooks/useAircraft.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useAircraft } from './useAircraft';
 import * as service from '../services/aircraft';
+import { deriveAircraftQuery, AIRCRAFT_MIN_ZOOM } from '../services/aircraft';
 
 const SAMPLE = [
   { id: 'air:abc', line: 'SAS123', mode: 'aircraft', latitude: 59.3, longitude: 18.0 },
@@ -63,5 +64,46 @@ describe('useAircraft', () => {
     unmount();
     resolvePending(SAMPLE);
     await new Promise(r => setTimeout(r, 10));
+  });
+});
+
+// Zoom gate + viewport-radius derivation (PRD #165, Slice 2). These drive the
+// hook through the same deriveAircraftQuery seam App uses, asserting the gate at
+// the hook boundary: no fetch below the threshold, a viewport-derived
+// centre/radius at/above it, with the radius clamped to 250 nm.
+describe('useAircraft — zoom-gated viewport fetching', () => {
+  const STHLM_BOUNDS = { south: 59.2, west: 17.8, north: 59.45, east: 18.3 };
+  const WIDE_BOUNDS = { south: 40, west: 0, north: 70, east: 30 };
+
+  beforeEach(() => {
+    vi.spyOn(service, 'fetchAircraft').mockResolvedValue(SAMPLE);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('does not fetch below the zoom threshold', () => {
+    const query = deriveAircraftQuery(STHLM_BOUNDS, AIRCRAFT_MIN_ZOOM - 1);
+    renderHook(() => useAircraft(query, { enabled: true }));
+    expect(service.fetchAircraft).not.toHaveBeenCalled();
+  });
+
+  it('fetches a viewport-derived centre/radius at the zoom threshold', async () => {
+    const query = deriveAircraftQuery(STHLM_BOUNDS, AIRCRAFT_MIN_ZOOM);
+    renderHook(() => useAircraft(query, { enabled: true }));
+    await waitFor(() => expect(service.fetchAircraft).toHaveBeenCalled());
+    const arg = service.fetchAircraft.mock.calls[0][0];
+    expect(arg.lat).toBeCloseTo((59.2 + 59.45) / 2, 5);
+    expect(arg.lon).toBeCloseTo((17.8 + 18.3) / 2, 5);
+    expect(arg.radius).toBeGreaterThan(0);
+    expect(arg.radius).toBeLessThan(250);
+  });
+
+  it('clamps the requested radius to 250 nm for a wide viewport', async () => {
+    const query = deriveAircraftQuery(WIDE_BOUNDS, AIRCRAFT_MIN_ZOOM);
+    renderHook(() => useAircraft(query, { enabled: true }));
+    await waitFor(() => expect(service.fetchAircraft).toHaveBeenCalled());
+    expect(service.fetchAircraft.mock.calls[0][0].radius).toBe(250);
   });
 });

--- a/src/hooks/useFilterSelection.js
+++ b/src/hooks/useFilterSelection.js
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { ALL_MODE_IDS } from '../services/modes';
+import { ALL_MODE_IDS, AIRCRAFT_MODE_IDS } from '../services/modes';
 
 // Favourites are Essential storage (ADR 0001) — a record of the user's own UI
 // choice, like theme. Versioned key lets a future shape change re-initialise
@@ -124,6 +124,9 @@ export function useFilterSelection(allVehicles) {
   const availableLines = useMemo(() => {
     const groups = {};
     for (const vehicle of vehicles) {
+      // Aircraft callsigns are not Lines (CONTEXT.md, PRD #165): keep aircraft
+      // modes out of the line selector entirely. They stay filterable by mode.
+      if (AIRCRAFT_MODE_IDS.has(vehicle.mode)) continue;
       if (!enabledModeSet.has(vehicle.mode) || !vehicle.line) continue;
       if (!groups[vehicle.mode]) groups[vehicle.mode] = {};
       groups[vehicle.mode][vehicle.line] = (groups[vehicle.mode][vehicle.line] || 0) + 1;

--- a/src/hooks/useFilterSelection.test.js
+++ b/src/hooks/useFilterSelection.test.js
@@ -118,6 +118,58 @@ describe('useFilterSelection — Scenario Outline: Available lines grouped and n
   });
 });
 
+describe('useFilterSelection — Scenario: Line selector lists transit lines only, never callsigns (issue #169)', () => {
+  // A callsign is not a Line (CONTEXT.md). Aircraft/helicopter Vehicles carry a
+  // callsign in `line`, but they must never appear in the line selector — only
+  // transit lines do. Aircraft stay filterable by MODE.
+  it('aircraft and helicopter modes never appear in availableLines, even when present', () => {
+    const vehicles = [
+      v('v1', 'bus', '4'),
+      v('v2', 'train', '41'),
+      v('air:abc', 'aircraft', 'SAS123'),
+      v('air:def', 'helicopter', 'POL01'),
+    ];
+    const { result } = renderHook(() => useFilterSelection(vehicles));
+
+    expect(result.current.availableLines).toHaveProperty('bus');
+    expect(result.current.availableLines).toHaveProperty('train');
+    expect(result.current.availableLines).not.toHaveProperty('aircraft');
+    expect(result.current.availableLines).not.toHaveProperty('helicopter');
+  });
+
+  it('no aircraft callsign is listed as a selectable line', () => {
+    const vehicles = [
+      v('v1', 'bus', '4'),
+      v('air:abc', 'aircraft', 'SAS123'),
+    ];
+    const { result } = renderHook(() => useFilterSelection(vehicles));
+
+    const allListedLines = Object.values(result.current.availableLines)
+      .flat()
+      .map(l => l.line);
+    expect(allListedLines).not.toContain('SAS123');
+  });
+
+  it('aircraft and helicopter remain listed as mode toggles', () => {
+    const vehicles = [v('air:abc', 'aircraft', 'SAS123')];
+    const { result } = renderHook(() => useFilterSelection(vehicles));
+
+    expect(result.current.enabledModes).toContain('aircraft');
+    expect(result.current.enabledModes).toContain('helicopter');
+  });
+
+  it('toggling the aircraft mode still hides aircraft Vehicles', () => {
+    const vehicles = [v('v1', 'bus', '4'), v('air:abc', 'aircraft', 'SAS123')];
+    const { result } = renderHook(() => useFilterSelection(vehicles));
+
+    expect(result.current.filteredVehicles).toHaveLength(2);
+
+    act(() => result.current.toggleMode('aircraft'));
+
+    expect(result.current.filteredVehicles.map(x => x.id)).toEqual(['v1']);
+  });
+});
+
 describe('useFilterSelection — Scenario: Disabling a mode clears its selected lines', () => {
   it('selected line disappears from selectedLines when its mode is disabled', () => {
     const vehicles = [v('v1', 'bus', '4')];

--- a/src/hooks/useFollowVehicle.js
+++ b/src/hooks/useFollowVehicle.js
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Follow-a-vehicle logic, the test seam for the Followed-vehicle feature
+ * (PRD #165, slice #167). Given the live Vehicle list, the selected id and the
+ * follow flag, it:
+ *   - resolves the followed Vehicle's current position (so App can panTo it on
+ *     every update, at the user's current zoom — see Map's pan glue);
+ *   - emits a one-shot exit signal (`onExit`) when the followed id is no longer
+ *     in the feed, so follow ends silently (selection cleared, no error).
+ *
+ * Pure of any Leaflet/DOM concern: it only reads the list and reports. Follow is
+ * session-only (no persistence) and orthogonal to the command-center highlight.
+ *
+ * @param {{ vehicles?: Array, selectedVehicleId?: string|null, followMode?: boolean, onExit?: () => void }} params
+ * @returns {{ followedPosition: [number, number] | null }}
+ */
+export function useFollowVehicle({ vehicles = [], selectedVehicleId = null, followMode = false, onExit } = {}) {
+  const following = followMode && selectedVehicleId != null;
+  const followed = following
+    ? vehicles.find((v) => v.id === selectedVehicleId) ?? null
+    : null;
+
+  const followedPosition =
+    followed && followed.latitude != null && followed.longitude != null
+      ? [followed.latitude, followed.longitude]
+      : null;
+
+  // Fire the exit signal exactly once on the transition from present to absent,
+  // never on the initial render and never again while the id stays gone.
+  const onExitRef = useRef(onExit);
+  onExitRef.current = onExit;
+  const wasPresentRef = useRef(false);
+
+  useEffect(() => {
+    if (!following) {
+      wasPresentRef.current = false;
+      return;
+    }
+    const present = vehicles.some((v) => v.id === selectedVehicleId);
+    if (!present && wasPresentRef.current) {
+      onExitRef.current?.();
+    }
+    wasPresentRef.current = present;
+  }, [following, vehicles, selectedVehicleId]);
+
+  return { followedPosition };
+}

--- a/src/hooks/useFollowVehicle.test.js
+++ b/src/hooks/useFollowVehicle.test.js
@@ -89,4 +89,46 @@ describe('useFollowVehicle', () => {
     rerender({ vehicles: [vehicle('a', 59.3, 18.1)] });
     expect(onExit).toHaveBeenCalledTimes(1);
   });
+
+  // Slice #171: stop-following affordances. The empty-map click that ends follow
+  // is App/Map glue; its observable end state is asserted here at the hook seam —
+  // when follow turns off, the hook resolves no followedPosition, so the map has
+  // nothing to pan to and the follow accent is gone.
+  it('drops the followed position when following turns off (map-click stop)', () => {
+    const { result, rerender } = renderHook(
+      ({ followMode }) =>
+        useFollowVehicle({
+          vehicles: [vehicle('b', 60.1, 17.5)],
+          selectedVehicleId: 'b',
+          followMode,
+        }),
+      { initialProps: { followMode: true } },
+    );
+    expect(result.current.followedPosition).toEqual([60.1, 17.5]);
+
+    // App's map-click handler clears followMode + selectedVehicleId.
+    rerender({ followMode: false });
+    expect(result.current.followedPosition).toBeNull();
+  });
+
+  // Slice #171: no persistence. Follow is a session-only singleton — a reload
+  // must forget it. The hook owns no client storage; assert it never writes any
+  // across the full follow lifecycle (mount → follow → exit).
+  it('never writes follow state to client storage', () => {
+    const localSpy = vi.spyOn(window.localStorage.__proto__, 'setItem');
+    const sessionSpy = vi.spyOn(window.sessionStorage.__proto__, 'setItem');
+
+    const { rerender } = renderHook(
+      ({ vehicles, followMode }) =>
+        useFollowVehicle({ vehicles, selectedVehicleId: 'b', followMode }),
+      { initialProps: { vehicles: [vehicle('b', 60.1, 17.5)], followMode: true } },
+    );
+    rerender({ vehicles: [vehicle('b', 60.2, 17.6)], followMode: true });
+    rerender({ vehicles: [vehicle('a', 59.3, 18.0)], followMode: true }); // exit
+
+    expect(localSpy).not.toHaveBeenCalled();
+    expect(sessionSpy).not.toHaveBeenCalled();
+    localSpy.mockRestore();
+    sessionSpy.mockRestore();
+  });
 });

--- a/src/hooks/useFollowVehicle.test.js
+++ b/src/hooks/useFollowVehicle.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFollowVehicle } from './useFollowVehicle';
+
+function vehicle(id, latitude, longitude, overrides = {}) {
+  return { id, latitude, longitude, mode: 'bus', line: '17', ...overrides };
+}
+
+describe('useFollowVehicle', () => {
+  it('resolves the followed vehicle position from the live list', () => {
+    const list = [vehicle('a', 59.3, 18.0), vehicle('b', 60.1, 17.5)];
+    const { result } = renderHook(() =>
+      useFollowVehicle({ vehicles: list, selectedVehicleId: 'b', followMode: true }),
+    );
+    expect(result.current.followedPosition).toEqual([60.1, 17.5]);
+  });
+
+  it('tracks the followed vehicle to its new position on each update', () => {
+    const { result, rerender } = renderHook(
+      ({ vehicles }) =>
+        useFollowVehicle({ vehicles, selectedVehicleId: 'b', followMode: true }),
+      { initialProps: { vehicles: [vehicle('b', 60.1, 17.5)] } },
+    );
+    expect(result.current.followedPosition).toEqual([60.1, 17.5]);
+
+    rerender({ vehicles: [vehicle('b', 60.2, 17.6)] });
+    expect(result.current.followedPosition).toEqual([60.2, 17.6]);
+  });
+
+  it('does nothing when followMode is off', () => {
+    const onExit = vi.fn();
+    const { result } = renderHook(() =>
+      useFollowVehicle({
+        vehicles: [vehicle('b', 60.1, 17.5)],
+        selectedVehicleId: 'b',
+        followMode: false,
+        onExit,
+      }),
+    );
+    expect(result.current.followedPosition).toBeNull();
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('emits the exit signal when the followed vehicle leaves the feed', () => {
+    const onExit = vi.fn();
+    const { rerender } = renderHook(
+      ({ vehicles }) =>
+        useFollowVehicle({ vehicles, selectedVehicleId: 'b', followMode: true, onExit }),
+      { initialProps: { vehicles: [vehicle('b', 60.1, 17.5)] } },
+    );
+    expect(onExit).not.toHaveBeenCalled();
+
+    rerender({ vehicles: [vehicle('a', 59.3, 18.0)] });
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit the exit signal when not following', () => {
+    const onExit = vi.fn();
+    renderHook(() =>
+      useFollowVehicle({
+        vehicles: [vehicle('a', 59.3, 18.0)],
+        selectedVehicleId: 'b',
+        followMode: false,
+        onExit,
+      }),
+    );
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('exposes no position when following an id that is not in the feed', () => {
+    const { result } = renderHook(() =>
+      useFollowVehicle({
+        vehicles: [vehicle('a', 59.3, 18.0)],
+        selectedVehicleId: 'b',
+        followMode: true,
+      }),
+    );
+    expect(result.current.followedPosition).toBeNull();
+  });
+
+  it('emits exit only once while the vehicle remains absent', () => {
+    const onExit = vi.fn();
+    const { rerender } = renderHook(
+      ({ vehicles }) =>
+        useFollowVehicle({ vehicles, selectedVehicleId: 'b', followMode: true, onExit }),
+      { initialProps: { vehicles: [vehicle('b', 60.1, 17.5)] } },
+    );
+    rerender({ vehicles: [vehicle('a', 59.3, 18.0)] });
+    rerender({ vehicles: [vehicle('a', 59.3, 18.1)] });
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useNoticeAcknowledgement.js
+++ b/src/hooks/useNoticeAcknowledgement.js
@@ -4,7 +4,9 @@ import { useCallback, useState } from 'react';
 // Trafikverket was added as a third-party webcam image source (ADR 0001).
 // Bumped v2 → v3 when Windy and the curated webcam catalogue were added
 // as webcam data sources — the notice must name every active source.
-const STORAGE_KEY = 'rtt-privacy-notice-v3';
+// Bumped v3 → v4 when airplanes.live was added as the aircraft data source
+// (ADR 0007) — the notice must name every active source.
+const STORAGE_KEY = 'rtt-privacy-notice-v4';
 
 function readAcknowledged() {
   try {

--- a/src/services/aircraft.js
+++ b/src/services/aircraft.js
@@ -61,7 +61,14 @@ export function mapAircraft(ac) {
 
   const vehicles = [];
   for (const entry of ac) {
-    if (!entry || entry.lat == null || entry.lon == null) continue;
+    if (!entry) continue;
+    // Untrusted external source: require a finite position (a non-finite lat/lon
+    // would throw inside Leaflet) and a non-empty hex (the marker key is
+    // `air:<hex>`; missing hex would collapse distinct aircraft onto one
+    // `air:undefined` key). Entries failing either are dropped, mirroring the
+    // GTFS-RT fetcher's drop-on-missing-position discipline.
+    if (!Number.isFinite(entry.lat) || !Number.isFinite(entry.lon)) continue;
+    if (typeof entry.hex !== 'string' || entry.hex === '') continue;
     vehicles.push({
       id: `air:${entry.hex}`,
       line: (entry.flight ?? '').trim(),

--- a/src/services/aircraft.js
+++ b/src/services/aircraft.js
@@ -3,6 +3,46 @@ import { AIRPLANES_LIVE_BASE } from '../config/endpoints.js';
 // airplanes.live caps the point-query radius at 250 nautical miles.
 const MAX_RADIUS_NM = 250;
 
+// Aircraft are gated on zoom: below this level no aircraft are fetched or shown,
+// so the country-level view isn't flooded with planes and the 1 req/s budget is
+// spent only when aircraft are useful (PRD #165, user stories 5 & 7).
+export const AIRCRAFT_MIN_ZOOM = 8;
+
+// 1 nautical mile = 1.852 km; 1° latitude ≈ 111.32 km.
+const KM_PER_DEGREE_LAT = 111.32;
+const KM_PER_NM = 1.852;
+
+/**
+ * Derive an airplanes.live point query from the current viewport, gated on zoom.
+ *
+ * Below {@link AIRCRAFT_MIN_ZOOM}, or with no bounds yet, returns `null` so the
+ * caller issues no request at all and shows no aircraft. At/above the threshold,
+ * the query centre is the viewport midpoint and the radius is the half-diagonal
+ * (centre → corner) in nautical miles, clamped to {@link MAX_RADIUS_NM} — the
+ * source's maximum (PRD #165, user story 5).
+ *
+ * Uses an equirectangular approximation for the half-diagonal, which is ample
+ * for sizing a fetch radius at these latitudes.
+ *
+ * @param {{ south: number, west: number, north: number, east: number } | null} bounds
+ * @param {number} zoom
+ * @returns {{ lat: number, lon: number, radius: number } | null}
+ */
+export function deriveAircraftQuery(bounds, zoom) {
+  if (!bounds || zoom < AIRCRAFT_MIN_ZOOM) return null;
+
+  const { south, west, north, east } = bounds;
+  const lat = (south + north) / 2;
+  const lon = (west + east) / 2;
+
+  const latSpanKm = ((north - south) / 2) * KM_PER_DEGREE_LAT;
+  const lonSpanKm =
+    ((east - west) / 2) * KM_PER_DEGREE_LAT * Math.cos((lat * Math.PI) / 180);
+  const halfDiagonalNm = Math.sqrt(latSpanKm ** 2 + lonSpanKm ** 2) / KM_PER_NM;
+
+  return { lat, lon, radius: Math.min(halfDiagonalNm, MAX_RADIUS_NM) };
+}
+
 /**
  * Pure mapping: airplanes.live `ac[]` entries → the existing Vehicle shape, so
  * aircraft flow through the unchanged marker pipeline (PRD #165).

--- a/src/services/aircraft.js
+++ b/src/services/aircraft.js
@@ -1,0 +1,65 @@
+import { AIRPLANES_LIVE_BASE } from '../config/endpoints.js';
+
+// airplanes.live caps the point-query radius at 250 nautical miles.
+const MAX_RADIUS_NM = 250;
+
+/**
+ * Pure mapping: airplanes.live `ac[]` entries → the existing Vehicle shape, so
+ * aircraft flow through the unchanged marker pipeline (PRD #165).
+ *
+ * An Aircraft is a Vehicle with no operator (CONTEXT.md): `line` carries the
+ * trimmed callsign, `bearing = track`, `speed = gs`. `mode` is `helicopter`
+ * when the source category is A7 (rotorcraft), otherwise `aircraft`. Extra
+ * fields { type, reg, altitude } drive the identifying popup. Entries without a
+ * current position are dropped, mirroring the GTFS-RT fetcher.
+ *
+ * @param {object[]} ac
+ * @returns {object[]}
+ */
+export function mapAircraft(ac) {
+  if (!Array.isArray(ac)) return [];
+
+  const vehicles = [];
+  for (const entry of ac) {
+    if (!entry || entry.lat == null || entry.lon == null) continue;
+    vehicles.push({
+      id: `air:${entry.hex}`,
+      line: (entry.flight ?? '').trim(),
+      lineName: '',
+      mode: entry.category === 'A7' ? 'helicopter' : 'aircraft',
+      latitude: entry.lat,
+      longitude: entry.lon,
+      bearing: entry.track ?? 0,
+      speed: entry.gs ?? 0,
+      // Popup extras — identify the flight.
+      type: entry.desc,
+      reg: entry.r,
+      altitude: entry.alt_baro,
+    });
+  }
+  return vehicles;
+}
+
+/**
+ * Fetch live aircraft around a point and map them into Vehicles.
+ *
+ * Aircraft are non-essential overlay data: a failed or malformed fetch is
+ * tolerated silently (resolves to []), so transit Vehicles are unaffected and
+ * no error is surfaced (PRD #165). Radius is capped at {@link MAX_RADIUS_NM}.
+ *
+ * @param {{ lat: number, lon: number, radius: number }} params
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function fetchAircraft({ lat, lon, radius }, { fetchImpl = fetch } = {}) {
+  const cappedRadius = Math.min(radius, MAX_RADIUS_NM);
+  const url = `${AIRPLANES_LIVE_BASE}/point/${lat}/${lon}/${cappedRadius}`;
+  try {
+    const response = await fetchImpl(url);
+    if (!response.ok) return [];
+    const data = await response.json();
+    return mapAircraft(data?.ac);
+  } catch {
+    return [];
+  }
+}

--- a/src/services/aircraft.js
+++ b/src/services/aircraft.js
@@ -1,0 +1,72 @@
+// Aircraft mapping service — the airspace counterpart to the GTFS-RT fetcher
+// (trafiklab.js). Aircraft come from airplanes.live: unauthenticated, CORS-open,
+// no proxy, no backend (ADR 0001). An Aircraft is a Vehicle with no operator
+// (see CONTEXT.md): `line` carries the callsign; the popup also shows type,
+// registration and altitude.
+
+import { AIRPLANES_LIVE_BASE } from '../config/endpoints.js';
+
+// airplanes.live caps the point-query radius at 250 nautical miles.
+export const AIRPLANES_LIVE_MAX_RADIUS_NM = 250;
+
+// A7 = rotorcraft (verified live: a Bell 429 returned category "A7").
+// Every other category — and a missing one — is a fixed-wing aircraft.
+function categoryToMode(category) {
+  return category === 'A7' ? 'helicopter' : 'aircraft';
+}
+
+/**
+ * Pure mapping of an airplanes.live `ac[]` array into the existing Vehicle
+ * shape, so aircraft flow through the unchanged marker pipeline. Entries with
+ * no current position are dropped (mirrors the GTFS fetcher).
+ *
+ * @param {Array<object>} ac
+ * @returns {object[]}
+ */
+export function mapAircraft(ac) {
+  if (!Array.isArray(ac)) return [];
+  const vehicles = [];
+  for (const a of ac) {
+    if (a == null) continue;
+    if (a.lat == null || a.lon == null) continue;
+    vehicles.push({
+      id: `air:${a.hex}`,
+      // operator deliberately absent — an Aircraft has no operator.
+      line: typeof a.flight === 'string' ? a.flight.trim() : '',
+      lineName: '',
+      mode: categoryToMode(a.category),
+      latitude: a.lat,
+      longitude: a.lon,
+      bearing: a.track ?? 0,
+      speed: a.gs ?? 0,
+      // Extras for the popup.
+      type: a.desc,
+      reg: a.r,
+      altitude: a.alt_baro,
+    });
+  }
+  return vehicles;
+}
+
+/**
+ * Fetch the current viewport from airplanes.live and map it into Vehicles.
+ * Tolerates every failure silently (aircraft are non-essential overlay data):
+ * an unreachable, non-ok, or malformed response resolves to `[]`, so transit
+ * Vehicles are unaffected and no error is surfaced.
+ *
+ * @param {{ lat: number, lon: number, radius: number }} query
+ * @returns {Promise<object[]>}
+ */
+export async function fetchAircraft({ lat, lon, radius }) {
+  const cappedRadius = Math.min(radius, AIRPLANES_LIVE_MAX_RADIUS_NM);
+  const url = `${AIRPLANES_LIVE_BASE}/point/${lat}/${lon}/${cappedRadius}`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return [];
+    const data = await response.json();
+    if (!Array.isArray(data?.ac)) return [];
+    return mapAircraft(data.ac);
+  } catch {
+    return [];
+  }
+}

--- a/src/services/aircraft.test.js
+++ b/src/services/aircraft.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mapAircraft, fetchAircraft, AIRPLANES_LIVE_MAX_RADIUS_NM } from './aircraft';
+
+// One realistic airplanes.live entry, trimmed to the fields the mapping reads.
+function rawAircraft(overrides = {}) {
+  return {
+    hex: '4ca7b1',
+    flight: 'SAS123  ',
+    lat: 59.33,
+    lon: 18.07,
+    track: 270,
+    gs: 420,
+    category: 'A3',
+    desc: 'BOEING 737-800',
+    r: 'SE-ABC',
+    alt_baro: 35000,
+    ...overrides,
+  };
+}
+
+describe('mapAircraft — pure mapping into the Vehicle shape', () => {
+  it('maps an aircraft entry into a Vehicle with no operator', () => {
+    const [v] = mapAircraft([rawAircraft()]);
+    expect(v.id).toBe('air:4ca7b1');
+    expect(v.latitude).toBe(59.33);
+    expect(v.longitude).toBe(18.07);
+    expect(v.bearing).toBe(270);
+    expect(v.speed).toBe(420);
+    expect(v.operator).toBeUndefined();
+  });
+
+  it('carries the callsign as the line, trimmed of trailing spaces', () => {
+    const [v] = mapAircraft([rawAircraft({ flight: 'SAS123  ' })]);
+    expect(v.line).toBe('SAS123');
+  });
+
+  it('exposes type, registration and altitude for the popup', () => {
+    const [v] = mapAircraft([rawAircraft()]);
+    expect(v.type).toBe('BOEING 737-800');
+    expect(v.reg).toBe('SE-ABC');
+    expect(v.altitude).toBe(35000);
+  });
+
+  describe('category → mode', () => {
+    const cases = [
+      ['A7', 'helicopter'],
+      ['A1', 'aircraft'],
+      ['A3', 'aircraft'],
+      ['', 'aircraft'],
+      [undefined, 'aircraft'],
+    ];
+    for (const [category, mode] of cases) {
+      it(`category ${JSON.stringify(category)} → ${mode}`, () => {
+        const [v] = mapAircraft([rawAircraft({ category })]);
+        expect(v.mode).toBe(mode);
+      });
+    }
+  });
+
+  it('drops entries without a current latitude/longitude', () => {
+    const out = mapAircraft([
+      rawAircraft({ hex: 'a', lat: 59, lon: 18 }),
+      rawAircraft({ hex: 'b', lat: undefined, lon: 18 }),
+      rawAircraft({ hex: 'c', lat: 59, lon: undefined }),
+      rawAircraft({ hex: 'd', lat: undefined, lon: undefined }),
+    ]);
+    expect(out.map(v => v.id)).toEqual(['air:a']);
+  });
+
+  it('tolerates missing optional fields', () => {
+    const [v] = mapAircraft([{ hex: 'x', lat: 59, lon: 18 }]);
+    expect(v.id).toBe('air:x');
+    expect(v.mode).toBe('aircraft');
+    expect(v.bearing).toBe(0);
+    expect(v.speed).toBe(0);
+  });
+
+  it('returns an empty array for a non-array input', () => {
+    expect(mapAircraft(undefined)).toEqual([]);
+    expect(mapAircraft(null)).toEqual([]);
+  });
+});
+
+describe('fetchAircraft — thin client over airplanes.live', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('queries the point endpoint and returns mapped Vehicles', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ac: [rawAircraft()] }),
+    });
+    const out = await fetchAircraft({ lat: 59.33, lon: 18.07, radius: 100 });
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('air:4ca7b1');
+    const url = fetchSpy.mock.calls[0][0];
+    expect(url).toContain('59.33');
+    expect(url).toContain('18.07');
+    expect(url).toContain('100');
+  });
+
+  it('caps the radius at the airplanes.live maximum', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ac: [] }),
+    });
+    await fetchAircraft({ lat: 59, lon: 18, radius: 9999 });
+    const url = fetchSpy.mock.calls[0][0];
+    expect(url).toContain(String(AIRPLANES_LIVE_MAX_RADIUS_NM));
+    expect(url).not.toContain('9999');
+  });
+
+  it('resolves to [] when the response is not ok', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 503 });
+    await expect(fetchAircraft({ lat: 59, lon: 18, radius: 50 })).resolves.toEqual([]);
+  });
+
+  it('resolves to [] when the fetch rejects (unreachable source)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+    await expect(fetchAircraft({ lat: 59, lon: 18, radius: 50 })).resolves.toEqual([]);
+  });
+
+  it('resolves to [] when the response is malformed (no ac array)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ unexpected: true }),
+    });
+    await expect(fetchAircraft({ lat: 59, lon: 18, radius: 50 })).resolves.toEqual([]);
+  });
+});

--- a/src/services/aircraft.test.js
+++ b/src/services/aircraft.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { mapAircraft, fetchAircraft } from './aircraft';
+import { mapAircraft, fetchAircraft, deriveAircraftQuery, AIRCRAFT_MIN_ZOOM } from './aircraft';
 
 function makeAc(overrides = {}) {
   return {
@@ -118,5 +118,41 @@ describe('fetchAircraft', () => {
       json: async () => ({ unexpected: true }),
     });
     await expect(fetchAircraft({ lat: 59, lon: 18, radius: 100 })).resolves.toEqual([]);
+  });
+});
+
+describe('deriveAircraftQuery — zoom gate + viewport-derived centre/radius', () => {
+  // A tight Stockholm-area viewport, well under 250 nm across.
+  const STHLM_BOUNDS = { south: 59.2, west: 17.8, north: 59.45, east: 18.3 };
+
+  it('returns null below the zoom threshold (no fetch issued)', () => {
+    expect(deriveAircraftQuery(STHLM_BOUNDS, AIRCRAFT_MIN_ZOOM - 1)).toBeNull();
+  });
+
+  it('returns null when there are no bounds yet', () => {
+    expect(deriveAircraftQuery(null, AIRCRAFT_MIN_ZOOM + 2)).toBeNull();
+  });
+
+  it('returns a query at the zoom threshold', () => {
+    expect(deriveAircraftQuery(STHLM_BOUNDS, AIRCRAFT_MIN_ZOOM)).not.toBeNull();
+  });
+
+  it('derives the centre as the viewport midpoint', () => {
+    const q = deriveAircraftQuery(STHLM_BOUNDS, AIRCRAFT_MIN_ZOOM);
+    expect(q.lat).toBeCloseTo((59.2 + 59.45) / 2, 5);
+    expect(q.lon).toBeCloseTo((17.8 + 18.3) / 2, 5);
+  });
+
+  it('derives a radius covering the viewport corner (positive, comfortably under the cap here)', () => {
+    const q = deriveAircraftQuery(STHLM_BOUNDS, AIRCRAFT_MIN_ZOOM);
+    expect(q.radius).toBeGreaterThan(0);
+    expect(q.radius).toBeLessThan(250);
+  });
+
+  it('clamps the radius to 250 nm for a viewport wider than 250 nm', () => {
+    // A continent-spanning viewport: half-diagonal far exceeds 250 nm.
+    const wide = { south: 40, west: 0, north: 70, east: 30 };
+    const q = deriveAircraftQuery(wide, AIRCRAFT_MIN_ZOOM);
+    expect(q.radius).toBe(250);
   });
 });

--- a/src/services/aircraft.test.js
+++ b/src/services/aircraft.test.js
@@ -56,6 +56,27 @@ describe('mapAircraft — pure aircraft → Vehicle mapping', () => {
     expect(result[0].id).toBe('air:4ac9b2');
   });
 
+  it('drops entries with a non-finite position (untrusted source hardening)', () => {
+    const result = mapAircraft([
+      makeAc({ hex: 'nan', lat: NaN, lon: 18 }),
+      makeAc({ hex: 'str', lat: '59.3', lon: 18 }),
+      makeAc({ hex: 'inf', lat: 59.3, lon: Infinity }),
+      makeAc({ hex: 'good', lat: 59.3, lon: 18 }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('air:good');
+  });
+
+  it('drops entries with a missing or empty hex (would collapse onto air:undefined)', () => {
+    const result = mapAircraft([
+      makeAc({ hex: undefined }),
+      makeAc({ hex: '' }),
+      makeAc({ hex: 'ok' }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('air:ok');
+  });
+
   it('tolerates missing optional fields', () => {
     const [v] = mapAircraft([
       { hex: 'abc', lat: 60, lon: 17 },

--- a/src/services/aircraft.test.js
+++ b/src/services/aircraft.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mapAircraft, fetchAircraft } from './aircraft';
+
+function makeAc(overrides = {}) {
+  return {
+    hex: '4ac9b2',
+    flight: 'SAS123  ',
+    r: 'SE-ABC',
+    desc: 'Boeing 737-800',
+    alt_baro: 35000,
+    gs: 420.5,
+    track: 180,
+    lat: 59.3,
+    lon: 18.0,
+    category: 'A1',
+    ...overrides,
+  };
+}
+
+describe('mapAircraft — pure aircraft → Vehicle mapping', () => {
+  it('maps an aircraft entry to a Vehicle with all required fields', () => {
+    const [v] = mapAircraft([makeAc()]);
+    expect(v.id).toBe('air:4ac9b2');
+    expect(v.latitude).toBe(59.3);
+    expect(v.longitude).toBe(18.0);
+    expect(v.bearing).toBe(180);
+    expect(v.speed).toBe(420.5);
+    expect(v.line).toBe('SAS123');           // trailing spaces trimmed
+    expect(v.mode).toBe('aircraft');
+    expect(v.type).toBe('Boeing 737-800');
+    expect(v.reg).toBe('SE-ABC');
+    expect(v.altitude).toBe(35000);
+  });
+
+  it('has no operator (Aircraft is a Vehicle with no operator)', () => {
+    const [v] = mapAircraft([makeAc()]);
+    expect(v.operator).toBeUndefined();
+  });
+
+  it.each([
+    ['A7', 'helicopter'],
+    ['A1', 'aircraft'],
+    ['A3', 'aircraft'],
+    [undefined, 'aircraft'],
+  ])('category %s → mode %s', (category, mode) => {
+    const [v] = mapAircraft([makeAc({ category })]);
+    expect(v.mode).toBe(mode);
+  });
+
+  it('drops an entry without a position (no lat/lon)', () => {
+    const result = mapAircraft([
+      makeAc({ hex: 'nopos', lat: undefined, lon: undefined }),
+      makeAc(),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('air:4ac9b2');
+  });
+
+  it('tolerates missing optional fields', () => {
+    const [v] = mapAircraft([
+      { hex: 'abc', lat: 60, lon: 17 },
+    ]);
+    expect(v.id).toBe('air:abc');
+    expect(v.bearing).toBe(0);
+    expect(v.speed).toBe(0);
+    expect(v.line).toBe('');
+  });
+
+  it('returns an empty array for a non-array / nullish input', () => {
+    expect(mapAircraft(null)).toEqual([]);
+    expect(mapAircraft(undefined)).toEqual([]);
+    expect(mapAircraft({})).toEqual([]);
+  });
+});
+
+describe('fetchAircraft', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('queries the point endpoint and maps the returned ac[]', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ac: [makeAc()] }),
+    });
+    const vehicles = await fetchAircraft({ lat: 59.3, lon: 18.0, radius: 100 });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0][0]).toContain('59.3');
+    expect(fetchSpy.mock.calls[0][0]).toContain('18');
+    expect(fetchSpy.mock.calls[0][0]).toContain('100');
+    expect(vehicles).toHaveLength(1);
+    expect(vehicles[0].mode).toBe('aircraft');
+  });
+
+  it('caps the radius at 250 nm', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ac: [] }),
+    });
+    await fetchAircraft({ lat: 59.3, lon: 18.0, radius: 9999 });
+    expect(fetchSpy.mock.calls[0][0]).toContain('250');
+    expect(fetchSpy.mock.calls[0][0]).not.toContain('9999');
+  });
+
+  it('returns [] on a non-ok response (silent failure)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 503 });
+    await expect(fetchAircraft({ lat: 59, lon: 18, radius: 100 })).resolves.toEqual([]);
+  });
+
+  it('returns [] when the fetch rejects (silent failure)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+    await expect(fetchAircraft({ lat: 59, lon: 18, radius: 100 })).resolves.toEqual([]);
+  });
+
+  it('returns [] on a malformed response (no ac[])', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ unexpected: true }),
+    });
+    await expect(fetchAircraft({ lat: 59, lon: 18, radius: 100 })).resolves.toEqual([]);
+  });
+});

--- a/src/services/anomalyRules.test.js
+++ b/src/services/anomalyRules.test.js
@@ -82,6 +82,25 @@ describe('detectStationaryAnomalies — stationary on active trip', () => {
     expect(detectStationaryAnomalies([], 0)).toEqual([]);
   });
 
+  // Issue #169 — a hovering helicopter is an Aircraft, not transit, and must
+  // never raise a stationary-vehicle Anomaly. Aircraft Vehicles (mapAircraft
+  // shape: `air:`+hex id, helicopter mode, no operator, no tripId) carry no
+  // active trip, so even if one reached this rule it raises nothing.
+  it('does not flag a hovering helicopter (no active trip, aircraft Vehicle)', () => {
+    const helicopter = (overrides = {}) => ({
+      id: 'air:4ca7b2',
+      mode: 'helicopter',
+      line: 'POL01',
+      latitude: 59.3293,
+      longitude: 18.0686,
+      ...overrides,
+    });
+    // Perfectly stationary over well past the threshold — would flag if it were
+    // a transit vehicle on an active trip, but a helicopter has no tripId.
+    const snaps = track([0, 3 * MIN, 6 * MIN], () => helicopter());
+    expect(detectStationaryAnomalies(snaps, 6 * MIN)).toHaveLength(0);
+  });
+
   it('ignores tiny jitter below the displacement threshold', () => {
     // ~10 m of GPS jitter, under the 30 m threshold → still counts as stationary.
     const snaps = track([0, 3 * MIN, 6 * MIN], (time) => {

--- a/src/services/feedOutageRules.test.js
+++ b/src/services/feedOutageRules.test.js
@@ -32,6 +32,26 @@ describe('detectFeedOutageAnomalies', () => {
     expect(detectFeedOutageAnomalies([], 0)).toEqual([]);
   });
 
+  // Issue #169 — airplanes.live is never a Watched operator or Feed-outage
+  // subject. Aircraft come from a separate hook whose outcomes never enter the
+  // transit feed series, so airplanes.live never appears in snapshot.feeds and
+  // can never be the subject of an outage Anomaly — even with aircraft Vehicles
+  // present in the snapshot's vehicle list (which this rule ignores entirely).
+  it('never raises an airplanes.live-subject outage even with aircraft on the map', () => {
+    const aircraftVehicle = { id: 'air:4ca7b2', mode: 'helicopter', line: 'POL01' };
+    const snaps = [
+      { time: 0, vehicles: [aircraftVehicle], feeds: [feed({ ok: true })] },
+      { time: 1 * MIN, vehicles: [aircraftVehicle], feeds: [feed({ ok: false, vehicleCount: 0, dataTimestamp: null })] },
+      { time: 2 * MIN, vehicles: [aircraftVehicle], feeds: [feed({ ok: false, vehicleCount: 0, dataTimestamp: null })] },
+      { time: 3 * MIN, vehicles: [aircraftVehicle], feeds: [feed({ ok: false, vehicleCount: 0, dataTimestamp: null })] },
+    ];
+    const anomalies = detectFeedOutageAnomalies(snaps, 3 * MIN);
+
+    // The transit operator may flag (it failed), but airplanes.live never does.
+    expect(anomalies.every((a) => a.operator !== 'airplanes.live')).toBe(true);
+    expect(anomalies.map((a) => a.operator)).not.toContain('air');
+  });
+
   describe('signal: repeated fetch failures', () => {
     it('raises a feed-fetch-failure anomaly after a streak of failed fetches', () => {
       const snaps = [

--- a/src/services/markerCollection.test.js
+++ b/src/services/markerCollection.test.js
@@ -275,6 +275,47 @@ describe('vehiclePopupContent — HTML escaping', () => {
     expect(html).not.toContain('<B>');
     expect(html).toMatch(/&lt;[Bb]&gt;/);
   });
+
+  describe('aircraft popup (no operator; identifying fields)', () => {
+    const aircraft = {
+      id: 'air:abc', mode: 'aircraft', line: 'SAS123',
+      type: 'Boeing 737-800', reg: 'SE-ABC', altitude: 35000,
+      bearing: 180, speed: 120, timestamp: 1700000000,
+    };
+
+    it('shows callsign, type, registration, altitude, speed and bearing', () => {
+      const html = vehiclePopupContent(aircraft);
+      expect(html).toContain('SAS123');
+      expect(html).toContain('Boeing 737-800');
+      expect(html).toContain('SE-ABC');
+      expect(html).toContain('35000');
+      expect(html).toMatch(/Bearing/i);
+      expect(html).toMatch(/Speed/i);
+    });
+
+    it('shows no operator for an aircraft', () => {
+      const html = vehiclePopupContent(aircraft);
+      expect(html).not.toMatch(/<em[^>]*>/); // operator line is the only <em>
+    });
+
+    it('escapes HTML in the aircraft type/reg fields', () => {
+      const html = vehiclePopupContent({
+        ...aircraft, type: '<b>x</b>', reg: '<i>y</i>',
+      });
+      expect(html).not.toContain('<b>x</b>');
+      expect(html).not.toContain('<i>y</i>');
+    });
+
+    it('omits the extra fields when absent (a transit vehicle popup is unchanged)', () => {
+      const html = vehiclePopupContent({
+        id: 'sl:1', mode: 'bus', line: '17', operator: 'sl',
+        bearing: 0, speed: 0, timestamp: 1700000000,
+      });
+      expect(html).not.toMatch(/Type:/i);
+      expect(html).not.toMatch(/Reg:/i);
+      expect(html).not.toMatch(/Altitude:/i);
+    });
+  });
 });
 
 // ─── Scenario 3: Vehicle without coordinates is skipped ──────────────────────

--- a/src/services/modes.js
+++ b/src/services/modes.js
@@ -4,6 +4,11 @@ export const MODES = [
   { id: 'train',   label: 'Train', color: '#95E1D3', icon: 'T' },
   { id: 'tram',    label: 'Tram',  color: '#F38181', icon: 'S' },
   { id: 'ferry',   label: 'Ferry', color: '#FCBAD3', icon: '⛴' },
+  // Aircraft modes come from the airplanes.live mapping, not GTFS — a mode no
+  // longer implies a GTFS origin (PRD #165). They get mode filter buttons for
+  // free and deliberately carry no GTFS route_type entry below.
+  { id: 'aircraft',   label: 'Aircraft',   color: '#6EC1E4', icon: '✈' },
+  { id: 'helicopter', label: 'Helicopter', color: '#B388FF', icon: '🚁' },
   { id: 'unknown', label: 'Other', color: '#888888', icon: '?' },
 ];
 

--- a/src/services/modes.js
+++ b/src/services/modes.js
@@ -4,6 +4,9 @@ export const MODES = [
   { id: 'train',   label: 'Train', color: '#95E1D3', icon: 'T' },
   { id: 'tram',    label: 'Tram',  color: '#F38181', icon: 'S' },
   { id: 'ferry',   label: 'Ferry', color: '#FCBAD3', icon: '⛴' },
+  // Non-GTFS modes — aircraft come from airplanes.live, not a GTFS route_type.
+  { id: 'aircraft',   label: 'Aircraft',   color: '#A29BFE', icon: '✈' },
+  { id: 'helicopter', label: 'Helicopter', color: '#74B9FF', icon: '🚁' },
   { id: 'unknown', label: 'Other', color: '#888888', icon: '?' },
 ];
 

--- a/src/services/modes.js
+++ b/src/services/modes.js
@@ -15,6 +15,13 @@ export const MODE_ICONS  = Object.fromEntries(MODES.map(m => [m.id, m.icon]));
 export const MODE_LABELS = Object.fromEntries(MODES.map(m => [m.id, m.label]));
 export const ALL_MODE_IDS = MODES.map(m => m.id);
 
+// The non-transit modes: aircraft come from airplanes.live, not a GTFS feed, and
+// a callsign is not a Line (CONTEXT.md). Single source of truth for "this Vehicle
+// is an Aircraft" — used to keep aircraft out of transit-only surfaces (the line
+// selector lists transit lines only; PRD #165, issue #169). Aircraft stay
+// filterable by mode.
+export const AIRCRAFT_MODE_IDS = new Set(['aircraft', 'helicopter']);
+
 export const GTFS_ROUTE_TYPE_TO_MODE = {
   '0':    'tram',
   '1':    'metro',

--- a/src/services/modes.test.js
+++ b/src/services/modes.test.js
@@ -5,6 +5,7 @@ import {
   MODE_ICONS,
   MODE_LABELS,
   ALL_MODE_IDS,
+  AIRCRAFT_MODE_IDS,
   GTFS_ROUTE_TYPE_TO_MODE,
   routeTypeToMode,
 } from './modes';
@@ -59,6 +60,25 @@ describe('MODES canonical list', () => {
 
   it('all mode ids are distinct', () => {
     expect(new Set(ALL_MODE_IDS).size).toBe(ALL_MODE_IDS.length);
+  });
+});
+
+describe('AIRCRAFT_MODE_IDS — the non-transit modes', () => {
+  it('contains exactly the aircraft and helicopter modes', () => {
+    expect([...AIRCRAFT_MODE_IDS].sort()).toEqual(['aircraft', 'helicopter']);
+  });
+
+  it('every aircraft mode is a real mode', () => {
+    for (const id of AIRCRAFT_MODE_IDS) {
+      expect(ALL_MODE_IDS).toContain(id);
+    }
+  });
+
+  it('no GTFS-emittable mode is an aircraft mode (aircraft are non-transit)', () => {
+    const emittable = new Set(Object.values(GTFS_ROUTE_TYPE_TO_MODE));
+    for (const id of emittable) {
+      expect(AIRCRAFT_MODE_IDS.has(id)).toBe(false);
+    }
   });
 });
 

--- a/src/services/modes.test.js
+++ b/src/services/modes.test.js
@@ -36,12 +36,25 @@ describe('MODES canonical list', () => {
     }
   });
 
-  it('every mode in the list is emittable (no permanently-empty filter)', () => {
+  it('every mode is either GTFS-emittable or a known non-GTFS mode', () => {
+    // A mode no longer implies a GTFS origin: aircraft/helicopter come from
+    // airplanes.live, not the GTFS route_type table.
     const emittable = new Set(Object.values(GTFS_ROUTE_TYPE_TO_MODE));
     emittable.add('unknown');
+    const NON_GTFS_MODES = new Set(['aircraft', 'helicopter']);
     for (const id of ALL_MODE_IDS) {
-      expect(emittable).toContain(id);
+      expect(emittable.has(id) || NON_GTFS_MODES.has(id)).toBe(true);
     }
+  });
+
+  it('includes aircraft and helicopter modes', () => {
+    expect(ALL_MODE_IDS).toContain('aircraft');
+    expect(ALL_MODE_IDS).toContain('helicopter');
+  });
+
+  it('does NOT extend the GTFS route_type table with aircraft modes', () => {
+    expect(Object.values(GTFS_ROUTE_TYPE_TO_MODE)).not.toContain('aircraft');
+    expect(Object.values(GTFS_ROUTE_TYPE_TO_MODE)).not.toContain('helicopter');
   });
 
   it('all mode ids are distinct', () => {

--- a/src/services/modes.test.js
+++ b/src/services/modes.test.js
@@ -39,9 +39,28 @@ describe('MODES canonical list', () => {
   it('every mode in the list is emittable (no permanently-empty filter)', () => {
     const emittable = new Set(Object.values(GTFS_ROUTE_TYPE_TO_MODE));
     emittable.add('unknown');
+    // aircraft/helicopter are emitted by the airplanes.live mapping, not GTFS
+    // (a mode no longer implies a GTFS origin — PRD #165).
+    emittable.add('aircraft');
+    emittable.add('helicopter');
     for (const id of ALL_MODE_IDS) {
       expect(emittable).toContain(id);
     }
+  });
+
+  it('includes aircraft (✈) and helicopter (🚁) modes', () => {
+    const aircraft = MODES.find(m => m.id === 'aircraft');
+    const helicopter = MODES.find(m => m.id === 'helicopter');
+    expect(aircraft).toBeTruthy();
+    expect(aircraft.icon).toBe('✈');
+    expect(helicopter).toBeTruthy();
+    expect(helicopter.icon).toBe('🚁');
+  });
+
+  it('does not give aircraft modes a GTFS route_type entry (mode ≠ GTFS origin)', () => {
+    const gtfsModes = new Set(Object.values(GTFS_ROUTE_TYPE_TO_MODE));
+    expect(gtfsModes).not.toContain('aircraft');
+    expect(gtfsModes).not.toContain('helicopter');
   });
 
   it('all mode ids are distinct', () => {

--- a/src/services/vehicleAdapter.js
+++ b/src/services/vehicleAdapter.js
@@ -6,12 +6,20 @@ export function vehiclePopupContent(vehicle) {
   const time = new Date((vehicle.timestamp ?? 0) * 1000).toLocaleTimeString('sv-SE');
   const speedKmh = ((vehicle.speed ?? 0) * 3.6).toFixed(1);
 
+  // Aircraft (a Vehicle with no operator) carry identifying extras for the
+  // popup; transit vehicles have none, so each line renders only when present.
+  const extras = [
+    vehicle.type != null ? `Type: ${escapeHtml(vehicle.type)}<br/>` : '',
+    vehicle.reg != null ? `Reg: ${escapeHtml(vehicle.reg)}<br/>` : '',
+    vehicle.altitude != null ? `Altitude: ${escapeHtml(vehicle.altitude)} ft<br/>` : '',
+  ].join('');
+
   return `
     <div style="font-family: sans-serif; min-width: 150px;">
       <strong style="font-size: 14px; text-transform: capitalize;">${escapeHtml(vehicle.mode)} ${escapeHtml(vehicle.line)}</strong><br/>
       ${vehicle.operator ? `<em style="color: #666; font-size: 12px;">${escapeHtml(vehicle.operator.toUpperCase())}</em><br/>` : ''}
       <hr style="margin: 5px 0; border: none; border-top: 1px solid #eee;"/>
-      Speed: ${speedKmh} km/h<br/>
+      ${extras}Speed: ${speedKmh} km/h<br/>
       Bearing: ${escapeHtml(vehicle.bearing)}°<br/>
       Updated: ${time}
     </div>

--- a/src/services/vehicleAdapter.js
+++ b/src/services/vehicleAdapter.js
@@ -3,8 +3,12 @@ import { MODE_COLORS, MODE_ICONS } from './modes';
 import { escapeHtml } from './markerCollection';
 
 export function vehiclePopupContent(vehicle, { followed = false } = {}) {
-  const time = new Date((vehicle.timestamp ?? 0) * 1000).toLocaleTimeString('sv-SE');
   const speedKmh = ((vehicle.speed ?? 0) * 3.6).toFixed(1);
+  // "Updated" only for Vehicles that carry a feed timestamp (transit). Aircraft
+  // have none, so the line is omitted rather than showing the 1970 epoch.
+  const updatedLine = vehicle.timestamp != null
+    ? `Updated: ${new Date(vehicle.timestamp * 1000).toLocaleTimeString('sv-SE')}`
+    : '';
   // Follow control: a single toggle button. Label flips to "Stop following" for
   // the currently-followed Vehicle (issue #167, stories 12 & 15). The click is
   // wired in onMarkerCreated via the [data-vehicle-follow] hook.
@@ -24,8 +28,7 @@ export function vehiclePopupContent(vehicle, { followed = false } = {}) {
       ${vehicle.operator ? `<em style="color: #666; font-size: 12px;">${escapeHtml(vehicle.operator.toUpperCase())}</em><br/>` : ''}
       <hr style="margin: 5px 0; border: none; border-top: 1px solid #eee;"/>
       ${typeLine}${regLine}${altitudeLine}Speed: ${speedKmh} km/h<br/>
-      Bearing: ${escapeHtml(vehicle.bearing)}°<br/>
-      Updated: ${time}
+      Bearing: ${escapeHtml(vehicle.bearing)}°${updatedLine ? `<br/>\n      ${updatedLine}` : ''}
       <hr style="margin: 5px 0; border: none; border-top: 1px solid #eee;"/>
       <button type="button" data-vehicle-follow style="
         width: 100%; padding: 4px 8px; cursor: pointer;
@@ -108,7 +111,14 @@ export function createVehicleAdapter({ isHighlighted = () => false, isPredicted 
 
   function updateOpenPopup(marker, vehicle) {
     if (typeof marker.isPopupOpen !== 'function' || !marker.isPopupOpen()) return;
-    if (typeof marker.setPopupContent === 'function') marker.setPopupContent(lazyPopupContent(vehicle));
+    if (typeof marker.setPopupContent !== 'function') return;
+    marker.setPopupContent(lazyPopupContent(vehicle));
+    // setPopupContent replaces the popup DOM, discarding the Follow listener
+    // wired on popupopen — re-wire it against the fresh content so the control
+    // keeps working across poll updates (otherwise it goes inert after ~2 s).
+    if (typeof marker.getPopup === 'function') {
+      wireFollowControl(marker.getPopup(), markerVehicles.get(marker) ?? vehicle);
+    }
   }
 
   function buildCompactIcon(color) {

--- a/src/services/vehicleAdapter.js
+++ b/src/services/vehicleAdapter.js
@@ -2,9 +2,13 @@ import L from 'leaflet';
 import { MODE_COLORS, MODE_ICONS } from './modes';
 import { escapeHtml } from './markerCollection';
 
-export function vehiclePopupContent(vehicle) {
+export function vehiclePopupContent(vehicle, { followed = false } = {}) {
   const time = new Date((vehicle.timestamp ?? 0) * 1000).toLocaleTimeString('sv-SE');
   const speedKmh = ((vehicle.speed ?? 0) * 3.6).toFixed(1);
+  // Follow control: a single toggle button. Label flips to "Stop following" for
+  // the currently-followed Vehicle (issue #167, stories 12 & 15). The click is
+  // wired in onMarkerCreated via the [data-vehicle-follow] hook.
+  const followLabel = followed ? 'Stop following' : 'Follow';
 
   return `
     <div style="font-family: sans-serif; min-width: 150px;">
@@ -14,6 +18,11 @@ export function vehiclePopupContent(vehicle) {
       Speed: ${speedKmh} km/h<br/>
       Bearing: ${escapeHtml(vehicle.bearing)}°<br/>
       Updated: ${time}
+      <hr style="margin: 5px 0; border: none; border-top: 1px solid #eee;"/>
+      <button type="button" data-vehicle-follow style="
+        width: 100%; padding: 4px 8px; cursor: pointer;
+        border: 1px solid #ccc; border-radius: 4px; background: #f5f5f5;
+      ">${followLabel}</button>
     </div>
   `;
 }
@@ -23,13 +32,18 @@ export function vehiclePopupContent(vehicle) {
 export const FULL_MARKER_MIN_ZOOM = 12;
 
 /**
- * @param {{ isHighlighted?: (vehicleId: string) => boolean, getZoom?: () => number }} [opts]
+ * @param {{ isHighlighted?: (vehicleId: string) => boolean, isFollowed?: (vehicleId: string) => boolean, onFollowToggle?: (vehicleId: string) => void, getZoom?: () => number }} [opts]
  *   isHighlighted lets the command-center view highlight vehicles involved in a
  *   selected Incident. Default: nothing highlighted (existing map view behaviour).
+ *   isFollowed marks the single Followed vehicle (issue #167). Its accent is a
+ *   distinct third visual state that COMPOSES with the highlight (both can be on
+ *   at once — follow and highlight are orthogonal) rather than replacing it.
+ *   onFollowToggle is invoked with the vehicle id when the popup Follow/Stop
+ *   control is activated, so App can flip session follow state.
  *   getZoom supplies the current map zoom; below FULL_MARKER_MIN_ZOOM markers
  *   render compact. Default: always full-size.
  */
-export function createVehicleAdapter({ isHighlighted = () => false, getZoom = () => FULL_MARKER_MIN_ZOOM } = {}) {
+export function createVehicleAdapter({ isHighlighted = () => false, isFollowed = () => false, onFollowToggle = () => {}, getZoom = () => FULL_MARKER_MIN_ZOOM } = {}) {
   const markerVehicles = new WeakMap();
   const markerVisualStateKeys = new WeakMap();
 
@@ -37,20 +51,40 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
     const color = MODE_COLORS[vehicle.mode] || MODE_COLORS.unknown;
     const icon = MODE_ICONS[vehicle.mode] || MODE_ICONS.unknown;
     const highlighted = isHighlighted(vehicle.id);
-    const compact = !highlighted && getZoom() < FULL_MARKER_MIN_ZOOM;
+    const followed = isFollowed(vehicle.id);
+    // Followed (like highlighted) stays full-size so its accent is legible even
+    // when the surrounding field is clustered/compact.
+    const compact = !highlighted && !followed && getZoom() < FULL_MARKER_MIN_ZOOM;
     const label = vehicle.line?.length <= 3 ? ['line', String(vehicle.line ?? '')] : ['icon', icon];
 
     return {
       color,
       icon,
       highlighted,
+      followed,
       compact,
-      key: JSON.stringify([compact, color, highlighted, label]),
+      key: JSON.stringify([compact, color, highlighted, followed, label]),
     };
   }
 
   function lazyPopupContent(vehicle) {
-    return (source) => vehiclePopupContent(markerVehicles.get(source) ?? vehicle);
+    return (source) => {
+      const v = markerVehicles.get(source) ?? vehicle;
+      return vehiclePopupContent(v, { followed: isFollowed(v.id) });
+    };
+  }
+
+  // Wire the Follow/Stop control once the popup is in the DOM. The control
+  // toggles follow for this Vehicle via onFollowToggle.
+  function wireFollowControl(popup, vehicle) {
+    const root = typeof popup.getElement === 'function' ? popup.getElement() : null;
+    if (!root) return;
+    const btn = root.querySelector('[data-vehicle-follow]');
+    if (!btn) return;
+    btn.addEventListener('click', (e) => {
+      if (typeof e.preventDefault === 'function') e.preventDefault();
+      onFollowToggle(vehicle.id);
+    });
   }
 
   function updateOpenPopup(marker, vehicle) {
@@ -82,11 +116,20 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
       return buildCompactIcon(state.color);
     }
     const border = state.highlighted ? '3px solid #ffd400' : '2px solid white';
-    const shadow = state.highlighted
+    // Follow accent: a distinct cyan ring/glow, deliberately unlike the gold
+    // highlight. It COMPOSES with the highlight — a followed+highlighted vehicle
+    // keeps the gold border and gains the cyan glow, so the two never fight.
+    let shadow = state.highlighted
       ? '0 0 0 3px rgba(255,212,0,0.5), 0 2px 4px rgba(0,0,0,0.3)'
       : '0 2px 4px rgba(0,0,0,0.3)';
+    if (state.followed) {
+      shadow = `0 0 0 4px rgba(0,200,255,0.85), ${shadow}`;
+    }
+    const classNames = ['vehicle-marker'];
+    if (state.highlighted) classNames.push('vehicle-marker--highlighted');
+    if (state.followed) classNames.push('vehicle-marker--followed');
     return L.divIcon({
-      className: state.highlighted ? 'vehicle-marker vehicle-marker--highlighted' : 'vehicle-marker',
+      className: classNames.join(' '),
       html: `
           <div style="
             background: ${state.color};
@@ -128,6 +171,11 @@ export function createVehicleAdapter({ isHighlighted = () => false, getZoom = ()
     onMarkerCreated(marker, vehicle) {
       markerVehicles.set(marker, vehicle);
       markerVisualStateKeys.set(marker, visualStateFor(vehicle).key);
+      if (typeof marker.on === 'function') {
+        marker.on('popupopen', (event) =>
+          wireFollowControl(event.popup, markerVehicles.get(marker) ?? vehicle),
+        );
+      }
     },
 
     onUpdate(marker, vehicle) {

--- a/src/services/vehicleAdapter.js
+++ b/src/services/vehicleAdapter.js
@@ -6,12 +6,20 @@ export function vehiclePopupContent(vehicle) {
   const time = new Date((vehicle.timestamp ?? 0) * 1000).toLocaleTimeString('sv-SE');
   const speedKmh = ((vehicle.speed ?? 0) * 3.6).toFixed(1);
 
+  // Aircraft extras (type / registration / altitude) — present only on
+  // aircraft Vehicles; absent for transit Vehicles, so the lines are omitted.
+  const typeLine = vehicle.type ? `Type: ${escapeHtml(vehicle.type)}<br/>` : '';
+  const regLine = vehicle.reg ? `Reg: ${escapeHtml(vehicle.reg)}<br/>` : '';
+  const altitudeLine = vehicle.altitude != null
+    ? `Altitude: ${escapeHtml(vehicle.altitude)} ft<br/>`
+    : '';
+
   return `
     <div style="font-family: sans-serif; min-width: 150px;">
       <strong style="font-size: 14px; text-transform: capitalize;">${escapeHtml(vehicle.mode)} ${escapeHtml(vehicle.line)}</strong><br/>
       ${vehicle.operator ? `<em style="color: #666; font-size: 12px;">${escapeHtml(vehicle.operator.toUpperCase())}</em><br/>` : ''}
       <hr style="margin: 5px 0; border: none; border-top: 1px solid #eee;"/>
-      Speed: ${speedKmh} km/h<br/>
+      ${typeLine}${regLine}${altitudeLine}Speed: ${speedKmh} km/h<br/>
       Bearing: ${escapeHtml(vehicle.bearing)}°<br/>
       Updated: ${time}
     </div>

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -180,6 +180,20 @@ describe('createVehicleAdapter downstream prediction accent', () => {
   });
 });
 
+describe('createVehicleAdapter aircraft glyphs', () => {
+  it('renders the ✈ glyph for an aircraft with a long callsign', () => {
+    const adapter = createVehicleAdapter({ getZoom: () => FULL_MARKER_MIN_ZOOM });
+    const icon = adapter.toIcon(makeVehicle({ mode: 'aircraft', line: 'SAS123', operator: undefined }));
+    expect(icon.html).toContain('✈');
+  });
+
+  it('renders the 🚁 glyph for a helicopter', () => {
+    const adapter = createVehicleAdapter({ getZoom: () => FULL_MARKER_MIN_ZOOM });
+    const icon = adapter.toIcon(makeVehicle({ mode: 'helicopter', line: 'POL01H', operator: undefined }));
+    expect(icon.html).toContain('🚁');
+  });
+});
+
 describe('createVehicleAdapter lazy popups', () => {
   it('defers vehicle popup formatting until Leaflet resolves popup content', () => {
     const adapter = createVehicleAdapter();

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -227,6 +227,33 @@ describe('createVehicleAdapter lazy popups', () => {
     expect(popupContent(marker)).toContain('bus 18');
   });
 
+  it('renders an aircraft popup with callsign, type, reg, altitude, speed and bearing — no operator', () => {
+    const adapter = createVehicleAdapter();
+    const marker = { isPopupOpen: () => false };
+    const aircraft = makeVehicle({
+      mode: 'aircraft',
+      line: 'SAS123',
+      operator: undefined,
+      bearing: 180,
+      speed: 200,
+      type: 'Boeing 737-800',
+      reg: 'SE-ABC',
+      altitude: 35000,
+    });
+
+    const popupContent = adapter.toPopup(aircraft);
+    adapter.onMarkerCreated(marker, aircraft);
+    const html = popupContent(marker);
+
+    expect(html).toContain('aircraft SAS123'); // callsign
+    expect(html).toContain('Type: Boeing 737-800');
+    expect(html).toContain('Reg: SE-ABC');
+    expect(html).toContain('Altitude: 35000 ft');
+    expect(html).toContain('Bearing: 180');
+    expect(html).toContain('km/h'); // speed
+    expect(html).not.toContain('<em'); // no operator line
+  });
+
   it('refreshes popup content only when the popup is open', () => {
     const adapter = createVehicleAdapter();
     let open = false;

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -211,6 +211,32 @@ describe('createVehicleAdapter follow accent', () => {
     expect(icon.className).toContain('vehicle-marker--followed');
   });
 
+  // Slice #171: following an already-highlighted Vehicle must layer the follow
+  // accent on without erasing the gold highlight — the live transition, not just
+  // the static composition above.
+  it('adds the follow accent to an already-highlighted vehicle without dropping the highlight', () => {
+    let followed = false;
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isHighlighted: (id) => id === 'v1',
+      isFollowed: () => followed,
+    });
+    const marker = {
+      setLatLng: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      isPopupOpen: () => false,
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    followed = true;
+    adapter.onUpdate(marker, makeVehicle());
+
+    expect(marker.setIcon).toHaveBeenCalledOnce();
+    const className = marker.setIcon.mock.calls[0][0].className;
+    expect(className).toContain('vehicle-marker--highlighted');
+    expect(className).toContain('vehicle-marker--followed');
+  });
+
   it('replaces the icon when follow state changes', () => {
     let followed = false;
     const adapter = createVehicleAdapter({

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -298,6 +298,39 @@ describe('createVehicleAdapter follow popup control', () => {
 
     expect(onFollowToggle).toHaveBeenCalledWith('v1');
   });
+
+  it('re-wires the follow control after a poll update replaces the open popup content', () => {
+    const onFollowToggle = vi.fn();
+    const adapter = createVehicleAdapter({ onFollowToggle });
+    const makeButton = () => {
+      const handlers = {};
+      return {
+        addEventListener: (ev, fn) => { handlers[ev] = fn; },
+        click: () => handlers.click?.({ preventDefault() {} }),
+      };
+    };
+    // setPopupContent replaces the button DOM node (new node, no listener),
+    // mirroring real Leaflet — so without re-wiring the post-update button is
+    // inert. getElement().querySelector always returns the CURRENT button.
+    let currentButton = makeButton();
+    const popup = {
+      getElement: () => ({ querySelector: (sel) => (sel.includes('follow') ? currentButton : null) }),
+    };
+    const marker = {
+      on: (ev, fn) => { if (ev === 'popupopen') fn({ popup }); },
+      isPopupOpen: () => true,
+      setLatLng: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      setPopupContent: () => { currentButton = makeButton(); return marker; },
+      getPopup: () => popup,
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());       // popupopen wires button A
+    adapter.onUpdate(marker, makeVehicle({ speed: 12 }));  // swaps to button B; fix re-wires it
+    currentButton.click();                                 // click the post-update button (B)
+
+    expect(onFollowToggle).toHaveBeenCalledWith('v1');
+  });
 });
 
 describe('createVehicleAdapter lazy popups', () => {
@@ -360,6 +393,24 @@ describe('createVehicleAdapter lazy popups', () => {
     expect(html).toContain('Bearing: 270');
     // No operator line for an aircraft.
     expect(html).not.toContain('<em');
+  });
+
+  it('omits the Updated line for an aircraft (no feed timestamp) but keeps it for transit', () => {
+    const adapter = createVehicleAdapter();
+    const aircraftMarker = {};
+    const aircraft = {
+      id: 'air:4ca7b1', mode: 'aircraft', line: 'SAS123',
+      latitude: 59.33, longitude: 18.07, bearing: 270, speed: 216,
+      // no timestamp — aircraft carry none
+    };
+    const aircraftPopup = adapter.toPopup(aircraft);
+    adapter.onMarkerCreated(aircraftMarker, aircraft);
+    expect(aircraftPopup(aircraftMarker)).not.toContain('Updated:');
+
+    const transitMarker = {};
+    const transitPopup = adapter.toPopup(makeVehicle());
+    adapter.onMarkerCreated(transitMarker, makeVehicle());
+    expect(transitPopup(transitMarker)).toContain('Updated:');
   });
 
   it('renders the helicopter glyph (🚁) on the marker icon for a helicopter Vehicle', () => {

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -153,6 +153,54 @@ describe('createVehicleAdapter lazy popups', () => {
     expect(popupContent(marker)).toContain('bus 18');
   });
 
+  it('renders an aircraft popup with callsign, type, reg, altitude, speed, bearing and no operator', () => {
+    const adapter = createVehicleAdapter();
+    const aircraft = {
+      id: 'air:4ca7b1',
+      mode: 'aircraft',
+      line: 'SAS123',
+      type: 'BOEING 737-800',
+      reg: 'SE-ABC',
+      altitude: 35000,
+      latitude: 59.33,
+      longitude: 18.07,
+      bearing: 270,
+      speed: 216,
+      timestamp: 1700000000,
+    };
+    const marker = {};
+    const popupContent = adapter.toPopup(aircraft);
+    adapter.onMarkerCreated(marker, aircraft);
+    const html = popupContent(marker);
+
+    expect(html).toContain('SAS123');
+    expect(html).toContain('BOEING 737-800');
+    expect(html).toContain('SE-ABC');
+    expect(html).toContain('35000');
+    expect(html).toContain('Bearing: 270');
+    // No operator line for an aircraft.
+    expect(html).not.toContain('<em');
+  });
+
+  it('renders the helicopter glyph (🚁) on the marker icon for a helicopter Vehicle', () => {
+    const adapter = createVehicleAdapter();
+    const icon = adapter.toIcon({
+      id: 'air:1', mode: 'helicopter', line: 'POL01', latitude: 59, longitude: 18,
+    });
+    expect(icon.html).toContain('🚁');
+  });
+
+  it('omits type/reg/altitude lines when the Vehicle has none (transit Vehicle)', () => {
+    const adapter = createVehicleAdapter();
+    const marker = {};
+    const popupContent = adapter.toPopup(makeVehicle());
+    adapter.onMarkerCreated(marker, makeVehicle());
+    const html = popupContent(marker);
+    expect(html).not.toContain('Type:');
+    expect(html).not.toContain('Reg:');
+    expect(html).not.toContain('Altitude:');
+  });
+
   it('refreshes popup content only when the popup is open', () => {
     const adapter = createVehicleAdapter();
     let open = false;

--- a/src/services/vehicleAdapter.test.js
+++ b/src/services/vehicleAdapter.test.js
@@ -120,6 +120,100 @@ describe('createVehicleAdapter zoom-adaptive icons', () => {
   });
 });
 
+describe('createVehicleAdapter follow accent', () => {
+  it('gives a followed vehicle a distinct follow visual-state key', () => {
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isFollowed: (id) => id === 'v1',
+    });
+    const icon = adapter.toIcon(makeVehicle());
+    expect(icon.className).toContain('vehicle-marker--followed');
+  });
+
+  it('keeps followed vehicles full-size even below the zoom threshold', () => {
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM - 3,
+      isFollowed: (id) => id === 'v1',
+    });
+    const icon = adapter.toIcon(makeVehicle());
+    expect(icon.iconSize).toEqual([24, 24]);
+  });
+
+  it('composes the follow accent with the highlight rather than replacing it', () => {
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isHighlighted: (id) => id === 'v1',
+      isFollowed: (id) => id === 'v1',
+    });
+    const icon = adapter.toIcon(makeVehicle());
+    // Follow and highlight are orthogonal — both accents present at once.
+    expect(icon.className).toContain('vehicle-marker--highlighted');
+    expect(icon.className).toContain('vehicle-marker--followed');
+  });
+
+  it('replaces the icon when follow state changes', () => {
+    let followed = false;
+    const adapter = createVehicleAdapter({
+      getZoom: () => FULL_MARKER_MIN_ZOOM,
+      isFollowed: () => followed,
+    });
+    const marker = {
+      setLatLng: vi.fn().mockReturnThis(),
+      setIcon: vi.fn().mockReturnThis(),
+      isPopupOpen: () => false,
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    followed = true;
+    adapter.onUpdate(marker, makeVehicle());
+
+    expect(marker.setIcon).toHaveBeenCalledOnce();
+    expect(marker.setIcon.mock.calls[0][0].className).toContain('vehicle-marker--followed');
+  });
+
+  it('defaults to nothing followed (existing map view behaviour)', () => {
+    const adapter = createVehicleAdapter();
+    const icon = adapter.toIcon(makeVehicle());
+    expect(icon.className).not.toContain('vehicle-marker--followed');
+  });
+});
+
+describe('createVehicleAdapter follow popup control', () => {
+  it('offers a Follow control in the popup for a not-yet-followed vehicle', () => {
+    const adapter = createVehicleAdapter();
+    const popupContent = adapter.toPopup(makeVehicle());
+    const marker = {};
+    adapter.onMarkerCreated(marker, makeVehicle());
+    expect(popupContent(marker)).toContain('Follow');
+  });
+
+  it('shows Stop following in the popup for the followed vehicle', () => {
+    const adapter = createVehicleAdapter({ isFollowed: (id) => id === 'v1' });
+    const popupContent = adapter.toPopup(makeVehicle());
+    const marker = {};
+    adapter.onMarkerCreated(marker, makeVehicle());
+    expect(popupContent(marker)).toContain('Stop following');
+  });
+
+  it('invokes the follow toggle when the popup control is activated', () => {
+    const onFollowToggle = vi.fn();
+    const adapter = createVehicleAdapter({ onFollowToggle });
+    const handlers = {};
+    const button = { addEventListener: (ev, fn) => { handlers[ev] = fn; } };
+    const popup = {
+      getElement: () => ({ querySelector: (sel) => (sel.includes('follow') ? button : null) }),
+    };
+    const marker = {
+      on: (ev, fn) => { if (ev === 'popupopen') fn({ popup }); },
+    };
+
+    adapter.onMarkerCreated(marker, makeVehicle());
+    handlers.click({ preventDefault() {} });
+
+    expect(onFollowToggle).toHaveBeenCalledWith('v1');
+  });
+});
+
 describe('createVehicleAdapter lazy popups', () => {
   it('defers vehicle popup formatting until Leaflet resolves popup content', () => {
     const adapter = createVehicleAdapter();


### PR DESCRIPTION
## Summary

Implements **PRD #165** end-to-end — a live aircraft/helicopter overlay plus click-to-follow for any vehicle. Built via `/dynamic-tdd` across 6 TDD slices, merged into this one feature branch.

**Part 1 — Aircraft**
- New `aircraft` (✈) and `helicopter` (🚁) modes in `modes.js` (the GTFS `route_type` table is deliberately *not* extended — a mode no longer implies a GTFS origin).
- `services/aircraft.js`: pure `mapAircraft()` (airplanes.live `ac[]` → Vehicle shape; `A7`→helicopter else aircraft; `air:<hex>` id; callsign→`line`; no operator) + `fetchAircraft()` + `deriveAircraftQuery()` (viewport centre/radius, capped 250 nm).
- `useAircraft` hook: fixed ~2 s cadence, pauses on tab-hidden, **zoom-gated (≥8)**, tolerates fetch/parse failure silently.
- Merged into the map's Vehicle list at the App level; aircraft render through the unchanged keyed marker pipeline with an identifying popup.
- **Isolation**: aircraft never enter the Command Center pipeline, and callsigns are excluded from the line filter (`AIRCRAFT_MODE_IDS`) — still filterable by mode.

**Part 2 — Click-to-follow**
- `useFollowVehicle` hook resolves the followed Vehicle's live position and emits a silent exit when it leaves the feed.
- Popup **Follow / Stop following** control; map `panTo` keeps the followed Vehicle centred at the current zoom; distinct cyan follow accent that **composes** with the gold highlight; stop via the control, an empty-map click, or feed-exit. Works for **any** vehicle type, aircraft included. Session-only (no persistence).

**Disclosure** — ADR 0007 records the airplanes.live choice (unauthenticated + CORS-open ⇒ fits the client-only, no-proxy architecture of ADR 0001) and its Non-Commercial-Use / no-SLA constraint; the Privacy Notice names the source.

## ⚠️ HITL — needs human sign-off (issue #170)
Slice #170 adds **ADR 0007** and the **airplanes.live Non-Commercial-Use licence / disclosure framing**. This is a human-in-the-loop judgment — please review the licence framing before merge.

## Gated tail (already run on this branch)
- **Simplify pass** — deduped the marker id-set update blocks; follow state uses the lighter `createIdSetState`.
- **Aspire runtime verification** — launched the SPA, exercised every slice against live airplanes.live + GTFS-RT. Found & fixed a **zoom-gate wiring bug**: the gate read App's `mapZoom` (only set on geolocation/region-select), so zooming out via the map controls kept fetching aircraft at country view. Now gates on the live viewport zoom reported with the bounds. Re-verified: 0 fetches below zoom 8, resumes above.
- **Local Codex PR review** — 5 findings fixed, each with tests: aircraft follow tracked the transit-only list (broke aircraft follow); the popup Follow listener went inert after a poll replaced the popup DOM; aircraft "Updated" line showed the 1970 epoch; `useAircraft` could apply a stale-viewport fetch after a query change; `mapAircraft` payload validation hardened (finite lat/lon + non-empty hex). XSS surface and Command-Center/line-filter isolation confirmed clean.

## Test plan
- ✅ `npm test` — **613 passed** (44 files); new tests beside each changed file (the popup re-wire test fails without its fix).
- ✅ `npm run build` — succeeds; sourcemaps off; no airplanes.live key in source (unauthenticated).
- ✅ Security analysis — all popup fields HTML-escaped; no new secrets; no dependency changes (the `npm audit` undici high is a pre-existing dev-only jsdom transitive dep).
- ✅ Runtime (Aspire + browser) — aircraft render with ✈ glyph + identifying popup (no operator); zoom gate; follow an aircraft pans + accents; map-click stops; Privacy Notice names airplanes.live.

Closes #166
Closes #167
Closes #168
Closes #169
Closes #170
Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)